### PR TITLE
Fix for #206

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,7 +51,8 @@ export interface ITerminal {
   /**
    * Send a signal to the ptys' processes. This is not supported on Windows.
    * @param signal The signal to send, by default this is SIGHUP.
-   * @param sendToProcessGroup Wheter to send the signal to all processes in the terminals process group or just the initially started one.
+   * @param sendToProcessGroup Whether to send the signal to all processes in
+   * the terminals process group or just the root process.
    */
   kill(signal?: string, sendToProcessGroup?: boolean): void;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -49,11 +49,11 @@ export interface ITerminal {
   destroy(): void;
 
   /**
-   * Kill the pty.
-   * @param signal The signal to send, by default this is SIGHUP. This is not
-   * supported on Windows.
+   * Send a signal to the ptys' processes. This is not supported on Windows.
+   * @param signal The signal to send, by default this is SIGHUP.
+   * @param sendToProcessGroup Wheter to send the signal to all processes in the terminals process group or just the initially started one.
    */
-  kill(signal?: string): void;
+  kill(signal?: string, sendToProcessGroup?: boolean): void;
 
   /**
    * Set the pty socket encoding.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -120,7 +120,7 @@ export abstract class Terminal implements ITerminal {
   public abstract write(data: string): void;
   public abstract resize(cols: number, rows: number): void;
   public abstract destroy(): void;
-  public abstract kill(signal?: string): void;
+  public abstract kill(signal?: string, sendToProcessGroup?: boolean): void;
 
   public abstract get process(): string;
   public abstract get master(): Socket;

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -231,17 +231,15 @@ export class UnixTerminal extends Terminal {
     this._socket.destroy();
   }
 
-  public kill(signal: string = 'SIGHUP'): void {
+  public kill(signal: string = 'SIGHUP', sendToProcessGroup: boolean = false): void {
     if (signal in os.constants.signals) {
-      try {
-        // pty.kill will not be available on systems which don't support
-        // the TIOCSIG/TIOCSIGNAL ioctl
-        if (pty.kill && signal !== 'SIGHUP') {
-          pty.kill(this._fd, os.constants.signals[signal]);
-        } else {
-          process.kill(this.pid, signal);
-        }
-      } catch (e) { /* swallow */ }
+      // pty.kill will not be available on systems which don't support
+      // the TIOCSIG/TIOCSIGNAL ioctl
+      if (sendToProcessGroup && pty.kill) {
+        pty.kill(this._fd, os.constants.signals[signal]);
+      } else {
+        process.kill(this.pid, signal);
+      }
     } else {
       throw new Error('Unknown signal: ' + signal);
     }

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -157,7 +157,7 @@ export class WindowsTerminal extends Terminal {
     });
   }
 
-  public kill(signal?: string): void {
+  public kill(signal?: string, sendToProcessGroup?: boolean): void {
     this._defer(() => {
       if (signal) {
         throw new Error('Signals not supported on windows.');


### PR DESCRIPTION
To fix #206, I've added an additional fallback for pty.kill using TIOCGPGRP, introduced the optional sendToProcessGroup parameter to the kill function, and removed the try catch that swallows all errors. I've removed the try catch because I think it is better to know if an error occurs and why than to have it silently discarded.