### PR TITLE
index.ts: Use import instead of require

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,14 @@ import * as path from 'path';
 import { Terminal as BaseTerminal } from './terminal';
 import { ITerminal, IPtyOpenOptions, IPtyForkOptions } from './interfaces';
 import { ArgvOrCommandLine } from './types';
+import { WindowsTerminal } from './windowsTerminal';
+import { UnixTerminal } from './unixTerminal';
 
 let terminalCtor: any;
 if (process.platform === 'win32') {
-  terminalCtor = require('./windowsTerminal').WindowsTerminal;
+  terminalCtor = WindowsTerminal;
 } else {
-  terminalCtor = require('./unixTerminal').UnixTerminal;
+  terminalCtor = UnixTerminal;
 }
 
 /**


### PR DESCRIPTION
Static analysis tools aren't as good with require, so replace this usage
of require with import.  For example, I am not able to ctrl-click to the
definition of UnixTerminal before, and I am after.