### PR TITLE
Fix kill under conpty

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,15 @@
           ]
         },
         {
+          'target_name': 'conpty_console_list',
+          'include_dirs' : [
+            '<!(node -e "require(\'nan\')")'
+          ],
+          'sources' : [
+            'src/win/conpty_console_list.cc'
+          ]
+        },
+        {
           'target_name': 'pty',
           'include_dirs' : [
             '<!(node -e "require(\'nan\')")',

--- a/examples/killDeepTree/index.js
+++ b/examples/killDeepTree/index.js
@@ -12,7 +12,7 @@ var ptyProcess = pty.spawn(shell, [], {
 });
 
 ptyProcess.on('data', function(data) {
-  console.log(data);
+  process.stdout.write(data);
 });
 
 ptyProcess.write('start notepad\r');

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "ps-list": "^6.0.0",
     "tslint": "^5.12.1",
     "tslint-consistent-codestyle": "^1.15.0",
-    "typescript": "^3.2.2",
+    "typescript": "^3.2.2"
+  },
+  "optionalDependencies": {
     "windows-process-tree": "^0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "tsc": "tsc",
+    "watch": "tsc -w",
     "lint": "tslint 'src/**/*.ts'",
     "install": "node scripts/install.js",
     "postinstall": "node scripts/post-install.js",
@@ -46,11 +47,14 @@
   "devDependencies": {
     "@types/mocha": "^5.0.0",
     "@types/node": "^6.0.104",
+    "@types/ps-list": "^6.0.0",
     "cross-env": "^5.1.4",
     "mocha": "^5.0.5",
     "pollUntil": "^1.0.3",
+    "ps-list": "^6.0.0",
     "tslint": "^5.12.1",
     "tslint-consistent-codestyle": "^1.15.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "windows-process-tree": "^0.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,5 @@
     "tslint": "^5.12.1",
     "tslint-consistent-codestyle": "^1.15.0",
     "typescript": "^3.2.2"
-  },
-  "optionalDependencies": {
-    "windows-process-tree": "^0.2.3"
   }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -5,9 +5,6 @@ const path = require('path');
 const spawn = require('child_process').spawn;
 
 installWindowsProcessTree().then(() => {
-  if (code) {
-    throw new Error('npm i windows-process-tree failed with code ' + code);
-  }
   const gypArgs = ['rebuild'];
   if (process.env.NODE_PTY_DEBUG) {
     gypArgs.push('--debug');
@@ -35,9 +32,6 @@ function installWindowsProcessTree() {
       stdio: 'inherit'
     });
     npmProcess.on('exit', function (code) {
-      if (code) {
-        throw new Error('windows-process-tree install failed with code ' + code);
-      }
       resolve();
     });
   });

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -4,14 +4,7 @@ const os = require('os');
 const path = require('path');
 const spawn = require('child_process').spawn;
 
-// windows-process-tree is an optional dev dependency which npm does not support
-const npmArgs = ['i', '--no-save', 'windows-process-tree@0.2.3'];
-const npmProcess = spawn(os.platform() === 'win32' ? 'npm.cmd' : 'npm', npmArgs, {
-  cwd: path.join(__dirname, '..'),
-  stdio: 'inherit'
-});
-
-npmProcess.on('exit', function (code) {
+installWindowsProcessTree().then(() => {
   if (code) {
     throw new Error('npm i windows-process-tree failed with code ' + code);
   }
@@ -28,3 +21,24 @@ npmProcess.on('exit', function (code) {
     process.exit(code);
   });
 });
+
+// windows-process-tree is an optional dev dependency which npm does not support
+function installWindowsProcessTree() {
+  return new Promise(resolve => {
+    if (process.platform !== 'win32') {
+      resolve();
+      return;
+    }
+    const npmArgs = ['i', '--no-save', 'windows-process-tree@0.2.3'];
+    const npmProcess = spawn(os.platform() === 'win32' ? 'npm.cmd' : 'npm', npmArgs, {
+      cwd: path.join(__dirname, '..'),
+      stdio: 'inherit'
+    });
+    npmProcess.on('exit', function (code) {
+      if (code) {
+        throw new Error('windows-process-tree install failed with code ' + code);
+      }
+      resolve();
+    });
+  });
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -4,15 +4,27 @@ const os = require('os');
 const path = require('path');
 const spawn = require('child_process').spawn;
 
-const args = ['rebuild'];
-if (process.env.NODE_PTY_DEBUG) {
-  args.push('--debug');
-}
-const p = spawn(os.platform() === 'win32' ? 'node-gyp.cmd' : 'node-gyp', args, {
+// windows-process-tree is an optional dev dependency which npm does not support
+const npmArgs = ['i', '--no-save', 'windows-process-tree@0.2.3'];
+const npmProcess = spawn(os.platform() === 'win32' ? 'npm.cmd' : 'npm', npmArgs, {
   cwd: path.join(__dirname, '..'),
   stdio: 'inherit'
 });
 
-p.on('exit', function (code) {
-  process.exit(code);
+npmProcess.on('exit', function (code) {
+  if (code) {
+    throw new Error('npm i windows-process-tree failed with code ' + code);
+  }
+  const gypArgs = ['rebuild'];
+  if (process.env.NODE_PTY_DEBUG) {
+    gypArgs.push('--debug');
+  }
+  const gypProcess = spawn(os.platform() === 'win32' ? 'node-gyp.cmd' : 'node-gyp', gypArgs, {
+    cwd: path.join(__dirname, '..'),
+    stdio: 'inherit'
+  });
+
+  gypProcess.on('exit', function (code) {
+    process.exit(code);
+  });
 });

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -5,6 +5,8 @@ var RELEASE_DIR = path.join(__dirname, '..', 'build', 'Release');
 var BUILD_FILES = [
   path.join(RELEASE_DIR, 'conpty.node'),
   path.join(RELEASE_DIR, 'conpty.pdb'),
+  path.join(RELEASE_DIR, 'conpty_console_list.node'),
+  path.join(RELEASE_DIR, 'conpty_console_list.pdb'),
   path.join(RELEASE_DIR, 'pty.node'),
   path.join(RELEASE_DIR, 'pty.pdb'),
   path.join(RELEASE_DIR, 'winpty-agent.exe'),

--- a/src/conpty_console_list_agent.ts
+++ b/src/conpty_console_list_agent.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2019, Microsoft Corporation (MIT License).
+ *
+ * This module fetches the console process list for a particular PID. It must be
+ * called from a different process (child_process.fork) as there can only be a
+ * single console attached to a process.
+ */
+
+import { loadNative } from './utils';
+
+const getConsoleProcessList = loadNative('conpty_console_list').getConsoleProcessList;
+const shellPid = parseInt(process.argv[2], 10);
+const consoleProcessList = getConsoleProcessList(shellPid);
+process.send({ consoleProcessList });
+process.exit(0);

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -5,7 +5,6 @@
 interface IConptyNative {
   startProcess(file: string, cols: number, rows: number, debug: boolean, pipeName: string): IConptyProcess;
   connect(ptyId: number, commandLine: string, cwd: string, env: string[], onExitCallback: (exitCode: number) => void): { pid: number };
-  getProcessList(shellPid: number): number[];
   resize(ptyId: number, cols: number, rows: number): void;
   kill(ptyId: number): void;
 }

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -5,6 +5,7 @@
 interface IConptyNative {
   startProcess(file: string, cols: number, rows: number, debug: boolean, pipeName: string): IConptyProcess;
   connect(ptyId: number, commandLine: string, cwd: string, env: string[], onExitCallback: (exitCode: number) => void): { pid: number };
+  getProcessList(shellPid: number): number[];
   resize(ptyId: number, cols: number, rows: number): void;
   kill(ptyId: number): void;
 }

--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -419,50 +419,9 @@ static NAN_METHOD(PtyKill) {
     }
   }
 
-  // Fetch the console process tree
-  // auto processList = std::vector<DWORD>(64);
-  // auto processCount = GetConsoleProcessList(&processList[0], processList.size());
-  // if (processList.size() < processCount) {
-  //     processList.resize(processCount);
-  //     processCount = GetConsoleProcessList(&processList[0], processList.size());
-  // }
-
-  // // Kill the console process tree
-  // for (DWORD i = 0; i < processCount; i++) {
-  //   TerminateProcess(processList[i], 1);
-  // }
-
-  // Close the shell handle
   CloseHandle(handle->hShell);
 
   return info.GetReturnValue().SetUndefined();
-}
-
-static NAN_METHOD(PtyGetProcessList) {
-  Nan::HandleScope scope;
-
-  if (info.Length() != 1 ||
-      !info[0]->IsNumber()) {
-    Nan::ThrowError("Usage: pty.getProcessList(shellPid)");
-    return;
-  }
-
-  int shellPid = info[0]->Int32Value();
-
-  AttachConsole(shellPid);
-  auto processList = std::vector<DWORD>(64);
-  auto processCount = GetConsoleProcessList(&processList[0], processList.size());
-  if (processList.size() < processCount) {
-      processList.resize(processCount);
-      processCount = GetConsoleProcessList(&processList[0], processList.size());
-  }
-  FreeConsole();
-
-  auto result = Nan::New<v8::Array>(processCount);
-  for (DWORD i = 0; i < processCount; i++) {
-    result->Set(i, Nan::New<v8::Number>(processList[i]));
-  }
-  info.GetReturnValue().Set(result);
 }
 
 /**
@@ -475,7 +434,6 @@ extern "C" void init(v8::Handle<v8::Object> target) {
   Nan::SetMethod(target, "connect", PtyConnect);
   Nan::SetMethod(target, "resize", PtyResize);
   Nan::SetMethod(target, "kill", PtyKill);
-  Nan::SetMethod(target, "getProcessList", PtyGetProcessList);
 };
 
 NODE_MODULE(pty, init);

--- a/src/win/conpty_console_list.cc
+++ b/src/win/conpty_console_list.cc
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2019, Microsoft Corporation (MIT License).
+ */
+
+#include <nan.h>
+#include <windows.h>
+
+static NAN_METHOD(ApiConsoleProcessList) {
+  if (info.Length() != 1 ||
+      !info[0]->IsNumber()) {
+    Nan::ThrowError("Usage: getConsoleProcessList(shellPid)");
+    return;
+  }
+
+  const SHORT pid = info[0]->Uint32Value();
+
+  if (!FreeConsole()) {
+    Nan::ThrowError("FreeConsole failed");
+  }
+  if (!AttachConsole(pid)) {
+    Nan::ThrowError("AttachConsole failed");
+  }
+  auto processList = std::vector<DWORD>(64);
+  auto processCount = GetConsoleProcessList(&processList[0], processList.size());
+  if (processList.size() < processCount) {
+      processList.resize(processCount);
+      processCount = GetConsoleProcessList(&processList[0], processList.size());
+  }
+  FreeConsole();
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>();
+  for (DWORD i = 0; i < processCount; i++) {
+    result->Set(i, Nan::New<v8::Number>(processList[i]));
+  }
+  info.GetReturnValue().Set(result);
+}
+
+extern "C" void init(v8::Handle<v8::Object> target) {
+  Nan::HandleScope scope;
+  Nan::SetMethod(target, "getConsoleProcessList", ApiConsoleProcessList);
+};
+
+NODE_MODULE(pty, init);

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -54,7 +54,7 @@ export class WindowsPtyAgent {
     private _useConpty: boolean | undefined
   ) {
     if (this._useConpty === undefined || this._useConpty === true) {
-      this._useConpty = this._getWindowsBuildNumber() >= 17692;
+      this._useConpty = this._getWindowsBuildNumber() >= 18309;
     }
     if (this._useConpty) {
       if (!conptyNative) {

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -8,8 +8,12 @@ import * as fs from 'fs';
 import * as assert from 'assert';
 import { WindowsTerminal } from './windowsTerminal';
 import * as path from 'path';
-import { getProcessList } from 'windows-process-tree';
 import * as psList from 'ps-list';
+
+let getProcessList: any;
+if (process.platform === 'win32') {
+  getProcessList = require('windows-process-tree');
+}
 
 interface IProcessState {
   // Whether the PID must exist or must not exist
@@ -69,7 +73,7 @@ if (process.platform === 'win32') {
         term.write('notepad.exe\r');
         term.write('node.exe\r');
         setTimeout(() => {
-          getProcessList(term.pid, list => {
+          getProcessList(term.pid, (list: {name: string, pid: number}[]) => {
             assert.equal(list.length, 4);
             assert.equal(list[0].name, 'cmd.exe');
             assert.equal(list[1].name, 'powershell.exe');

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -12,7 +12,7 @@ import * as psList from 'ps-list';
 
 let getProcessList: any;
 if (process.platform === 'win32') {
-  getProcessList = require('windows-process-tree');
+  getProcessList = require('windows-process-tree').getProcessList;
 }
 
 interface IProcessState {

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -3,6 +3,7 @@
  * Copyright (c) 2018, Microsoft Corporation (MIT License).
  */
 
+import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as assert from 'assert';
 import { WindowsTerminal } from './windowsTerminal';
@@ -16,6 +17,16 @@ if (process.platform === 'win32') {
         term.kill();
         // Add done call to deferred function queue to ensure the kill call has completed
         (<any>term)._defer(done);
+      });
+      it('should kill the process tree', (done) => {
+        const term = new WindowsTerminal('cmd.exe', [], {});
+        // Start a sub-process
+        term.write('powershell.exe');
+        const proc = cp.execSync(`tasklist /fi "PID eq ${term.pid}"`);
+        const index = proc.toString().indexOf(term.pid.toString());
+        console.log('******* ' + index + ', ' + proc.toString());
+        // term.pid
+        // term.kill();
       });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "lib",
     "sourceMap": true,
     "lib": [
-      "es5"
+      "es2015"
     ],
     "alwaysStrict": true,
     "noImplicitAny": true,

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -28,8 +28,8 @@ declare module 'node-pty' {
     encoding?: string;
     /**
      * Whether to use the experimental ConPTY system on Windows. When this is not set, ConPTY will
-     * be used when the Windows build number is >= 18309 (it's available in 17692 but is considered
-     * unstable).
+     * be used when the Windows build number is >= 18309 (it's available in 17134 and 17692 but is
+     * too unstable to enable by default).
      *
      * This setting does nothing on non-Windows.
      */

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -28,7 +28,8 @@ declare module 'node-pty' {
     encoding?: string;
     /**
      * Whether to use the experimental ConPTY system on Windows. When this is not set, ConPTY will
-     * be used when the Windows build number is >= 17692.
+     * be used when the Windows build number is >= 18309 (it's available in 17692 but is considered
+     * unstable).
      *
      * This setting does nothing on non-Windows.
      */


### PR DESCRIPTION
Fixes #253 

---

Also set ConPTY to default on to 18309 (current Windows Insiders) due to PowerShell flicker bug and poor performance.