### PR TITLE
Revert "Use a less strict check on encoding to avoid if"

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -169,17 +169,21 @@ export class UnixTerminal extends Terminal {
 
     const cols = opt.cols || DEFAULT_COLS;
     const rows = opt.rows || DEFAULT_ROWS;
-    const encoding = opt.encoding ? 'utf8' : opt.encoding;
+    const encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
 
     // open
     const term: IUnixOpenProcess = pty.open(cols, rows);
 
     self._master = new PipeSocket(<number>term.master);
-    self._master.setEncoding(encoding);
+    if (encoding !== null) {
+        self._master.setEncoding(encoding);
+    }
     self._master.resume();
 
     self._slave = new PipeSocket(term.slave);
-    self._slave.setEncoding(encoding);
+    if (encoding !== null) {
+        self._slave.setEncoding(encoding);
+    }
     self._slave.resume();
 
     self._socket = self._master;


### PR DESCRIPTION
This reverts commit 16a36a86fcfe6e3fd86fdc52618b3f30e23db585.

That commit introduced a bug where Pty.open would return
an UTF8-encoded stream regardless of specified options.

Note that the if cannot be avoided, because setEncoding(null) defaults to utf-8, while we expect null to mean 'raw buffers'.