### PR TITLE
Remove dynamic loading method `loadNative`

### DIFF
--- a/src/conpty_console_list_agent.ts
+++ b/src/conpty_console_list_agent.ts
@@ -6,9 +6,13 @@
  * single console attached to a process.
  */
 
-import { loadNative } from './utils';
+let getConsoleProcessList: any;
+try {
+  getConsoleProcessList = require('../build/Release/conpty_console_list.node').getConsoleProcessList;
+} catch (err) {
+  getConsoleProcessList = require('../build/Debug/conpty_console_list.node').getConsoleProcessList;
+}
 
-const getConsoleProcessList = loadNative('conpty_console_list').getConsoleProcessList;
 const shellPid = parseInt(process.argv[2], 10);
 const consoleProcessList = getConsoleProcessList(shellPid);
 process.send({ consoleProcessList });

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,4 +50,4 @@ export function open(options: IPtyOpenOptions): ITerminal {
  * Expose the native API when not Windows, note that this is not public API and
  * could be removed at any time.
  */
-export const native = (process.platform !== 'win32' ? require(path.join('..', 'build', 'Release', 'pty.node')) : null);
+export const native = (process.platform !== 'win32' ? require('../build/Release/pty.node') : null);

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -8,9 +8,14 @@ import * as net from 'net';
 import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
 import { IProcessEnv, IPtyForkOptions, IPtyOpenOptions } from './interfaces';
 import { ArgvOrCommandLine } from './types';
-import { assign, loadNative } from './utils';
+import { assign } from './utils';
 
-const pty: IUnixNative = loadNative('pty');
+let pty: IUnixNative;
+try {
+  pty = require('../build/Release/pty.node');
+} catch {
+  pty = require('../build/Debug/pty.node');
+}
 
 const DEFAULT_FILE = 'sh';
 const DEFAULT_NAME = 'xterm';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,11 +9,3 @@ export function assign(target: any, ...sources: any[]): any {
   sources.forEach(source => Object.keys(source).forEach(key => target[key] = source[key]));
   return target;
 }
-
-export function loadNative(moduleName: string): any {
-  try {
-    return require(path.join('..', 'build', 'Release', `${moduleName}.node`));
-  } catch {
-    return require(path.join('..', 'build', 'Debug', `${moduleName}.node`));
-  }
-}

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -8,7 +8,6 @@ import * as os from 'os';
 import * as path from 'path';
 import { Socket } from 'net';
 import { ArgvOrCommandLine } from './types';
-import { loadNative } from './utils';
 import { fork } from 'child_process';
 
 let conptyNative: IConptyNative;
@@ -59,11 +58,19 @@ export class WindowsPtyAgent {
     }
     if (this._useConpty) {
       if (!conptyNative) {
-        conptyNative = loadNative('conpty');
+        try {
+          conptyNative = require('../build/Release/conpty.node');
+        } catch (err) {
+          conptyNative = require('../build/Debug/conpty.node');
+        }
       }
     } else {
       if (!winptyNative) {
-        winptyNative = loadNative('pty');
+        try {
+          winptyNative = require('../build/Release/pty.node');
+        } catch (err) {
+          winptyNative = require('../build/Debug/pty.node');
+        }
       }
     }
     this._ptyNative = this._useConpty ? conptyNative : winptyNative;


### PR DESCRIPTION
Use of this dynamic loading method is convenient, but makes it difficult for bundlers like webpack to operate. With a bit of extra bloat to node-pty, users of webpack will not need to treat the node-pty project as an 'external', and will be able to bundle it just like any other node module.
