### PR TITLE
package: remove @types/ps-list: ps-list provides its own type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "devDependencies": {
     "@types/mocha": "^5.0.0",
     "@types/node": "^6.0.104",
-    "@types/ps-list": "^6.0.0",
     "cross-env": "^5.1.4",
     "mocha": "^5.0.5",
     "pollUntil": "^1.0.3",


### PR DESCRIPTION
Removed `@types/ps-list`, because: 

```js
npm WARN deprecated @types/ps-list@6.2.1: This is a stub types definition. ps-list provides its own type definitions, so you do not need this installed.
```