### PR TITLE
Restore default ctrl+c handler in conpty support

### DIFF
--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -198,6 +198,9 @@ static NAN_METHOD(PtyStartProcess) {
   HPCON hpc;
   HRESULT hr = CreateNamedPipesAndPseudoConsole({cols, rows}, 0, &hIn, &hOut, &hpc, inName, outName, pipeName);
 
+  // Restore default handling of ctrl+c
+  SetConsoleCtrlHandler(NULL, FALSE);
+
   // Set return values
   marshal = Nan::New<v8::Object>();
 


### PR DESCRIPTION
Part of Microsoft/vscode#72629
Fixes #286