### PR TITLE
fix handle inheritance for shells

### DIFF
--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -320,6 +320,11 @@ static NAN_METHOD(PtyConnect) {
   // Attach the pseudoconsole to the client application we're creating
   STARTUPINFOEXW siEx{0};
   siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
+  siEx.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+  siEx.StartupInfo.hStdError = nullptr;
+  siEx.StartupInfo.hStdInput = nullptr;
+  siEx.StartupInfo.hStdOutput = nullptr;
+
   SIZE_T size = 0;
   InitializeProcThreadAttributeList(NULL, 1, 0, &size);
   BYTE *attrList = new BYTE[size];


### PR DESCRIPTION
Right now the launched shell with inherit handles from the process that launches it. This causes issues if stdin/stdout/stderr are named pipes. Turning off handle inheritance fixes this issue.