### PR TITLE
chore: Bump nan

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepublishOnly": "npm run tsc"
   },
   "dependencies": {
-    "nan": "^2.13.2"
+    "nan": "^2.14.0"
   },
   "devDependencies": {
     "@types/mocha": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -794,7 +794,7 @@ mute-stream@0.0.5:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
 
-nan@^2.13.2:
+nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==


### PR DESCRIPTION
So that users don't remove package-lock.json file when installing beta releases. https://github.com/microsoft/node-pty/issues/319#issuecomment-515364359