### PR TITLE
fix macOS electron 3.x compiles

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -34,7 +34,16 @@
 #if defined(__GLIBC__) || defined(__CYGWIN__)
 #include <pty.h>
 #elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
+/**
+ * From node v0.10.28 there is also a "util.h" in node/src, which
+ * confuses the compiler when looking for "util.h".
+ * without this compiles of electron 3.x in macOS fail.
+ */
+#if NODE_VERSION_AT_LEAST(10, 0, 0)
+#include <../include/util.h>
+#else
 #include <util.h>
+#endif
 #elif defined(__FreeBSD__)
 #include <libutil.h>
 #elif defined(__sun)


### PR DESCRIPTION
This was broken in https://github.com/microsoft/node-pty/commit/5db10ca4e3970a65492ee0bb7c1f02766d7d6628 made in https://github.com/microsoft/node-pty/pull/322

Consequence macOS builds for electron 3.x fail.

Error logs oof failure  https://travis-ci.org/oznu/node-pty-prebuilt-multiarch/jobs/567184687

Related PR where the issue was first noticed https://github.com/oznu/node-pty-prebuilt-multiarch/pull/2

Progress on issue  comment https://github.com/oznu/node-pty-prebuilt-multiarch/pull/2#issuecomment-517913067

Relevant part of log with error
```log
  CXX(target) Release/obj.target/pty/src/unix/pty.o
../src/unix/pty.cc:635:10: error: use of undeclared identifier 'openpty'
  return openpty(amaster, aslave, name, (termios *)termp, (winsize *)winp);
         ^
../src/unix/pty.cc:684:10: error: use of undeclared identifier 'forkpty'
  return forkpty(amaster, name, (termios *)termp, (winsize *)winp);
         ^
2 errors generated.
```

With this fix applied compiles are successful once again https://travis-ci.org/the-j0k3r/node-pty-prebuilt-multiarch/jobs/567269847


Notes: Chose node 8.0.0 because node-pty is building from node `8.0.0` up so `8.x` is minimum version.

https://github.com/microsoft/node-pty/blob/32ea3e47791794a82c58c76bf83dc4d441a93108/azure-pipelines.yml#L12