### PR TITLE
build: don't specify /usr/*/lib paths under libraries

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -55,9 +55,7 @@
           'src/unix/pty.cc'
         ],
         'libraries': [
-          '-lutil',
-          '-L/usr/lib',
-          '-L/usr/local/lib'
+          '-lutil'
         ],
         'conditions': [
           # http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html


### PR DESCRIPTION
Fixes https://github.com/microsoft/node-pty/issues/338