### PR TITLE
Fix building on OpenBSD with node 10

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -34,7 +34,11 @@
 #if defined(__GLIBC__) || defined(__CYGWIN__)
 #include <pty.h>
 #elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
-#include <util.h>
+/**
+ * From node v0.10.28 (at least?) there is also a "util.h" in node/src, which
+ * would confuse the compiler when looking for "util.h".
+ */
+#include <../include/util.h>
 #elif defined(__FreeBSD__)
 #include <libutil.h>
 #elif defined(__sun)


### PR DESCRIPTION
5db10ca broke compiling on OpenBSD (probably also Mac OS X/NetBSD), as
`.node-gyp/$NODE_VERSION/src/util.h` takes precendence over
`/usr/include/util.h`. the include that is used in pty.cc requires `/usr/include/util.h` and does not require any functions from nodes util.h

#339 was opened to revert this, but was declined because https://github.com/microsoft/node-pty/pull/339#issuecomment-519660578

> Its a bug in electron for shipping all node src headers instead of the necessary header.

However, I cannot  see how that affects a local build of node-pty that has nothing to do with electron and hence does not "ship" any headers, but automatically includes the headers in `.node-gyp/$NODE_VERSION/src/` downloaded by node-gyp.

Please consider this pull request, or add some information on how to build node-gyp on systems with this conflict.

