### PR TITLE
Add missing shebang to the demo Electron app

### DIFF
--- a/examples/electron/npm_install.sh
+++ b/examples/electron/npm_install.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env sh
+
 # Electron's version.
 export npm_config_target=4.0.1
 # The architecture of Electron, can be ia32 or x64.


### PR DESCRIPTION
## Description

`npm_install.sh` cannot execute successfully without a bash/shell [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) at the beginning of the script.
This change adds the missing shebang to the demo Electron app.

## Questions

I did not find a CONTRIBUTING md file, I apologize if this PR should've been done differently.