### PR TITLE
remove stdlib setting

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -68,13 +68,6 @@
           }],
           ['OS=="mac"', {
             "xcode_settings": {
-              "OTHER_CPLUSPLUSFLAGS": [
-                "-std=c++11",
-                "-stdlib=libc++"
-              ],
-              "OTHER_LDFLAGS": [
-                "-stdlib=libc++"
-              ],
               "MACOSX_DEPLOYMENT_TARGET":"10.7"
             }
           }]


### PR DESCRIPTION
v8 version 8.7 in electron 11 uses c++14 features.