### PR TITLE
Add ENiGMA½ to list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ ptyProcess.write('ls\r');
 - [DockerStacks](https://github.com/sfx101/docker-stacks) Local LAMP/LEMP stack using Docker
 - [TeleType](https://github.com/akshaykmr/TeleType): cli tool that allows you to share your terminal online conveniently. Show off mad cli-fu, help a colleague, teach, or troubleshoot.
 - [mesos-term](https://github.com/criteo/mesos-term): A web terminal for Apache Mesos. It allows to execute commands within containers.
+- [ENiGMA½ BBS Software](https://github.com/NuSkooler/enigma-bbs): A modern BBS software with a nostalgic flair!
 
 Do you use node-pty in your application as well? Please open a [Pull Request](https://github.com/Tyriar/node-pty/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
ENiGMA½ very much uses node-pty for the "Getting certain programs to think you're a terminal, such as when you need a program to send you control sequences" case -- allowing us to run various emulators, "doors", so on under a BBS.