### PR TITLE
Explicitly open winpty conin pipe in write-only mode - fixes #457

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ jobs:
     matrix:
       node_12_x:
         node_version: 12.x
+      node_14_x:
+        node_version: 14.x
   steps:
   - task: NodeTool@0
     inputs:
@@ -33,6 +35,8 @@ jobs:
     matrix:
       node_12_x:
         node_version: 12.x
+      node_14_x:
+        node_version: 14.x
   steps:
   - task: NodeTool@0
     inputs:
@@ -55,6 +59,8 @@ jobs:
     matrix:
       node_12_x:
         node_version: 12.x
+      node_14_x:
+        node_version: 14.x
   steps:
   - task: NodeTool@0
     inputs:

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -4,6 +4,7 @@
  * Copyright (c) 2018, Microsoft Corporation (MIT License).
  */
 
+import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { Socket } from 'net';
@@ -126,9 +127,13 @@ export class WindowsPtyAgent {
       this._outSocket.emit('ready_datapipe');
     });
 
-    this._inSocket = new Socket();
+    const inSocketFD = fs.openSync(term.conin, 'w');
+    this._inSocket = new Socket({
+      fd: inSocketFD,
+      readable: false,
+      writable: true
+    });
     this._inSocket.setEncoding('utf8');
-    this._inSocket.connect(term.conin);
 
     if (this._useConpty) {
       const connect = (this._ptyNative as IConptyNative).connect(this._pty, commandLine, cwd, env, c => this._$onProcessExit(c));

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -201,5 +201,15 @@ if (process.platform === 'win32') {
         });
       });
     });
+
+    describe('winpty', () => {
+      it('should accept input', (done) => {
+        const term = new WindowsTerminal('cmd.exe', '', { useConpty: false });
+        term.write('exit\r');
+        term.on('exit', () => {
+          done();
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
Apparently the issue is caused by Node opening pipe sockets in RW mode by default.

One point to consider is whether the pipe should be `open()`ed synchronously - however I'm pretty sure opening a named pipe is always instantaneous. Swapping it for an asynchronous open means initial writes would have to be buffered somewhere first.

I've also added a test that fails on Node 14 with vanilla `node-pty` right now.

Fixes #457