### PR TITLE
Disconnect IO handles during PtyKill

### DIFF
--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -318,8 +318,8 @@ static NAN_METHOD(PtyConnect) {
   auto envV = vectorFromString(env);
   LPWSTR envArg = envV.empty() ? nullptr : envV.data();
 
-  BOOL success = ConnectNamedPipe(handle->hIn, nullptr);
-  success = ConnectNamedPipe(handle->hOut, nullptr);
+  ConnectNamedPipe(handle->hIn, nullptr);
+  ConnectNamedPipe(handle->hOut, nullptr);
 
   // Attach the pseudoconsole to the client application we're creating
   STARTUPINFOEXW siEx{0};
@@ -442,6 +442,10 @@ static NAN_METHOD(PtyKill) {
       }
     }
 
+    DisconnectNamedPipe(handle->hIn);
+    DisconnectNamedPipe(handle->hOut);
+    CloseHandle(handle->hIn);
+    CloseHandle(handle->hOut);
     CloseHandle(handle->hShell);
   }
 


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/123056

I noticed some handles were still being left open after killing a pwsh terminal in VS Code. This PR closes the `hIn` and `hOut` handles during `PtyKill`. I'm currently following the docs at https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-operations, which suggest that the server can call `DisconnectNamedPipe`, and then call `CloseHandle` after.

Note that this fix at most helps with some cleanup during `PtyKill`, but it doesn't solve anything regarding `PtyConnect`.

Before merging:
- [x] Ensure CI passes. When trying to run the tests locally on Windows, I noticed that they would get stuck on the `automatic flow control` item. But, the same was happening for me even without the changes in this PR.
