### PR TITLE
update README with new onData pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ var ptyProcess = pty.spawn(shell, [], {
   env: process.env
 });
 
-ptyProcess.on('data', function(data) {
+ptyProcess.onData((data) => {
   process.stdout.write(data);
 });
 


### PR DESCRIPTION
See my idea here https://github.com/microsoft/node-pty/issues/552

Seems like the deprecated syntax needs updated from `ptyProcess.on('data', function (data) {` -> to -> `ptyProcess.onData((data: any) => {`