### PR TITLE
Add clang setting for macos to fix install issues with electron >=20

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -76,7 +76,8 @@
           'conditions': [
             ['OS=="mac"', {
               "xcode_settings": {
-                "MACOSX_DEPLOYMENT_TARGET":"10.7"
+                "MACOSX_DEPLOYMENT_TARGET":"10.7",
+                'CLANG_CXX_LANGUAGE_STANDARD': 'c++17'
               }
             }]
           ]
@@ -104,7 +105,8 @@
             }],
             ['OS=="mac"', {
               "xcode_settings": {
-                "MACOSX_DEPLOYMENT_TARGET":"10.7"
+                "MACOSX_DEPLOYMENT_TARGET":"10.7",
+                'CLANG_CXX_LANGUAGE_STANDARD': 'c++17'
               }
             }]
           ]


### PR DESCRIPTION
Experiencing the following error when install node-pay on >= 20. Adding the clang version resolves the issue. You can recreate this issue using electron-builder and install-app-deps.

```
   npm ERR! /Users/nick/.electron-gyp/21.0.1/include/node/v8-maybe.h:106:45: error: no template named 'is_lvalue_reference_v' in namespace 'std'; did you mean 'is_lvalue_reference'?
    npm ERR!   template <class U, std::enable_if_t<!std::is_lvalue_reference_v<U>>*>
    npm ERR!                                        ~~~~~^~~~~~~~~~~~~~~~~~~~~
    npm ERR!                                             is_lvalue_reference
```