### PR TITLE
warning fix

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -531,7 +531,7 @@ pty_after_waitpid(uv_async_t *async) {
 
   v8::Local<v8::Function> cb = Nan::New<v8::Function>(baton->cb);
   baton->cb.Reset();
-  memset(&baton->cb, -1, sizeof(baton->cb));
+  memset((void*)&baton->cb, -1, sizeof(baton->cb));
   Nan::AsyncResource resource("pty_after_waitpid");
   resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), cb, 2, argv);
 


### PR DESCRIPTION
Fix non-trivial copy assignment warning in memset usage

```
make: Entering directory '/home/jbud/repositories/node-pty/build'
  CXX(target) Release/obj.target/pty/src/unix/pty.o
../src/unix/pty.cc: In function ‘void pty_after_waitpid(uv_async_t*)’:
../src/unix/pty.cc:534:9: warning: ‘void* memset(void*, int, size_t)’ writing to an object of type ‘class Nan::Persistent<v8::Function>’ with no trivial copy-assignment [-Wclass-memaccess]
  534 |   memset(&baton->cb, -1, sizeof(baton->cb));
      |   ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```