### PR TITLE
fix: controlling terminal on macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -98,6 +98,20 @@
           ]
         }
       ]
+    }],
+    ['OS=="mac"', {
+      'targets': [
+        {
+          'target_name': 'spawn-helper',
+          'type': 'executable',
+          'sources': [
+            'src/unix/spawn-helper.cc',
+          ],
+          "xcode_settings": {
+            "MACOSX_DEPLOYMENT_TARGET":"10.7"
+          }
+        },
+      ]
     }]
   ]
 }

--- a/scripts/post-install.js
+++ b/scripts/post-install.js
@@ -9,6 +9,7 @@ var BUILD_FILES = [
   path.join(RELEASE_DIR, 'conpty_console_list.pdb'),
   path.join(RELEASE_DIR, 'pty.node'),
   path.join(RELEASE_DIR, 'pty.pdb'),
+  path.join(RELEASE_DIR, 'spawn-helper'),
   path.join(RELEASE_DIR, 'winpty-agent.exe'),
   path.join(RELEASE_DIR, 'winpty-agent.pdb'),
   path.join(RELEASE_DIR, 'winpty.dll'),

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -18,7 +18,7 @@ interface IWinptyNative {
 }
 
 interface IUnixNative {
-  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
+  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
   open(cols: number, rows: number): IUnixOpenProcess;
   process(fd: number, pty: string): string;
   process(pid: number): string;

--- a/src/unix/spawn-helper.cc
+++ b/src/unix/spawn-helper.cc
@@ -1,0 +1,23 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main (int argc, char** argv) {
+  char *slave_path = ttyname(STDIN_FILENO);
+  // open implicit attaches a process to a terminal device if:
+  // - process has no controlling terminal yet
+  // - O_NOCTTY is not set
+  close(open(slave_path, O_RDWR));
+
+  char *cwd = argv[1];
+  char *file = argv[2];
+  argv = &argv[2];
+
+  if (strlen(cwd) && chdir(cwd) == -1) {
+    _exit(1);
+  }
+
+  execvp(file, argv);
+  return 1;
+}

--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -255,38 +255,7 @@ if (process.platform !== 'win32') {
       });
     });
     describe('spawn', () => {
-      if (process.platform === 'linux') {
-        it('should handle exec() errors', (done) => {
-          const term = new UnixTerminal('/bin/bogus.exe', []);
-          term.on('exit', (code, signal) => {
-            assert.strictEqual(code, 1);
-            done();
-          });
-        });
-        it('should handle chdir() errors', (done) => {
-          const term = new UnixTerminal('/bin/echo', [], { cwd: '/nowhere' });
-          term.on('exit', (code, signal) => {
-            assert.strictEqual(code, 1);
-            done();
-          });
-        });
-      } else if (process.platform === 'darwin') {
-        it('should handle exec() errors', (done) => {
-          try {
-            new UnixTerminal('/bin/bogus.exe', []);
-            done(new Error('should have failed'));
-          } catch {
-            done();
-          }
-        });
-        it('should handle chdir() errors', (done) => {
-          try {
-            new UnixTerminal('/bin/echo', [], { cwd: '/nowhere' });
-            done(new Error('should have failed'));
-          } catch (e) {
-            done();
-          }
-        });
+      if (process.platform === 'darwin') {
         it('should return the name of the process', (done) => {
           const term = new UnixTerminal('/bin/echo');
           assert.strictEqual(term.process, '/bin/echo');
@@ -331,6 +300,20 @@ if (process.platform !== 'win32') {
           });
         });
       }
+      it('should handle exec() errors', (done) => {
+        const term = new UnixTerminal('/bin/bogus.exe', []);
+        term.on('exit', (code, signal) => {
+          assert.strictEqual(code, 1);
+          done();
+        });
+      });
+      it('should handle chdir() errors', (done) => {
+        const term = new UnixTerminal('/bin/echo', [], { cwd: '/nowhere' });
+        term.on('exit', (code, signal) => {
+          assert.strictEqual(code, 1);
+          done();
+        });
+      });
       it('should not leak child process', (done) => {
         const count = cp.execSync('ps -ax | grep node | wc -l');
         const term = new UnixTerminal('node', [ '-e', `


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/178693

Depends on https://github.com/microsoft/node-pty/pull/588

This brings back the helper executable to associate a controlling terminal for the child process created under new session, the change still ensures https://github.com/microsoft/vscode/issues/174956 is addressed.