### PR TITLE
Fix include marco for FreeBSD systems

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -36,6 +36,8 @@
 #include <pty.h>
 #elif defined(__APPLE__)
 #include <util.h>
+#elif defined(__FreeBSD__)
+#include <libutil.h>
 #endif
 
 /* Some platforms name VWERASE and VDISCARD differently */

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -32,12 +32,16 @@
 
 /* forkpty */
 /* http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html */
-#if defined(__linux__)
+#if defined(__GLIBC__) || defined(__CYGWIN__)
 #include <pty.h>
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
 #include <util.h>
 #elif defined(__FreeBSD__)
 #include <libutil.h>
+#elif defined(__sun)
+#include <stropts.h> /* for I_PUSH */
+#else
+#include <pty.h>
 #endif
 
 /* Some platforms name VWERASE and VDISCARD differently */

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -32,7 +32,7 @@
 
 /* forkpty */
 /* http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html */
-#if defined(__GLIBC__)
+#if defined(__linux__)
 #include <pty.h>
 #elif defined(__APPLE__)
 #include <util.h>

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -32,16 +32,12 @@
 
 /* forkpty */
 /* http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html */
-#if defined(__GLIBC__) || defined(__CYGWIN__)
+#if defined(__GLIBC__)
 #include <pty.h>
-#elif defined(__APPLE__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#elif defined(__APPLE__)
 #include <util.h>
 #elif defined(__FreeBSD__)
 #include <libutil.h>
-#elif defined(__sun)
-#include <stropts.h> /* for I_PUSH */
-#else
-#include <pty.h>
 #endif
 
 /* Some platforms name VWERASE and VDISCARD differently */


### PR DESCRIPTION
Per documented in https://www.gnu.org/software/gnulib/manual/html_node/forkpty.html:

> The function is declared in pty.h on glibc and Cygwin. It is declared in util.h on Mac OS X, OpenBSD, and NetBSD. It is declared in libutil.h on FreeBSD. It is declared in termios.h on Solaris.

See also: https://github.com/coder/code-server/issues/5741