### PR TITLE
add optional support to replace argv[0] (fixes #472)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -115,6 +115,7 @@ interface IBasePtyForkOptions {
 export interface IPtyForkOptions extends IBasePtyForkOptions {
   uid?: number;
   gid?: number;
+  argv0?: string;
 }
 
 export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -19,7 +19,7 @@ interface IWinptyNative {
 }
 
 interface IUnixNative {
-  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
+  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void, argv0: string): IUnixProcess;
   open(cols: number, rows: number): IUnixOpenProcess;
   process(fd: number, pty?: string): string;
   resize(fd: number, cols: number, rows: number): void;

--- a/src/unix/spawn-helper.cc
+++ b/src/unix/spawn-helper.cc
@@ -12,7 +12,7 @@ int main (int argc, char** argv) {
 
   char *cwd = argv[1];
   char *file = argv[2];
-  argv = &argv[2];
+  argv = &argv[3];
 
   if (strlen(cwd) && chdir(cwd) == -1) {
     _exit(1);

--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -365,6 +365,31 @@ if (process.platform !== 'win32') {
           }
         });
       });
+      it('should default argv0 to file', (done) => {
+        const term = new UnixTerminal('/bin/sh',
+          [ '-c', 'echo $0' ]);
+        let argv0 = '';
+        term.on('data', (data) => {
+          argv0 = argv0.concat(data);
+        });
+        term.on('exit', () => {
+          assert.strictEqual(argv0.trim(), '/bin/sh');
+          done();
+        });
+      });
+      it('should allow an alternate argv0', (done) => {
+        const term = new UnixTerminal('/bin/sh',
+          [ '-c', 'echo $0' ],
+          { argv0: 'alternate' });
+        let argv0 = '';
+        term.on('data', (data) => {
+          argv0 = argv0.concat(data);
+        });
+        term.on('exit', () => {
+          assert.strictEqual(argv0.trim(), 'alternate');
+          done();
+        });
+      });
     });
   });
 }

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -110,8 +110,10 @@ export class UnixTerminal extends Terminal {
       this.emit('exit', code, signal);
     };
 
+    const argv0 = opt.argv0 ?? file;
+
     // fork
-    const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
+    const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit, argv0);
 
     this._socket = new PipeSocket(term.fd);
     if (encoding !== null) {


### PR DESCRIPTION
With this, specifying the new property "argv0" in options will replace argv[0] with a custom string.

This is useful, for example, when starting a login shell:

```
const pty = spawn('/bin/zsh', [], {
  argv0: '-zsh'
});
```

If this property is omitted, the file parameter is used instead, which is identical to existing behavior.