### PR TITLE
Port to NAPI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,9 @@ jobs:
       versionSpec: $(node_version)
     displayName: 'Install Node.js'
   - script: |
+      python3 -m pip install setuptools
+    displayName: Install setuptools (macOS)
+  - script: |
       npm i
     displayName: 'Install dependencies and build'
   - script: |
@@ -54,7 +57,7 @@ jobs:
 
 - job: Windows
   pool:
-    vmImage: 'windows-2019'
+    vmImage: 'windows-latest'
   strategy:
     matrix:
       node_16_x:
@@ -87,7 +90,7 @@ jobs:
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '16.x'
+      versionSpec: '18.x'
     displayName: 'Install Node.js'
   - script: |
       npm i

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,5 +1,8 @@
 {
   'target_defaults': {
+    'dependencies': [
+      "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
+    ],
     'conditions': [
       ['OS=="win"', {
         'msvs_configuration_attributes': {
@@ -28,9 +31,7 @@
       'targets': [
         {
           'target_name': 'conpty',
-          'cflags!': [ '-fno-exceptions' ],
-          'cflags_cc!': [ '-fno-exceptions' ],
-          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'xcode_settings': {
             'CLANG_CXX_LIBRARY': 'libc++',
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
           },
@@ -50,9 +51,7 @@
         },
         {
           'target_name': 'conpty_console_list',
-          'cflags!': [ '-fno-exceptions' ],
-          'cflags_cc!': [ '-fno-exceptions' ],
-          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'xcode_settings': {
             'CLANG_CXX_LIBRARY': 'libc++',
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
           },
@@ -68,9 +67,7 @@
         },
         {
           'target_name': 'pty',
-          'cflags!': [ '-fno-exceptions' ],
-          'cflags_cc!': [ '-fno-exceptions' ],
-          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'xcode_settings': {
             'CLANG_CXX_LIBRARY': 'libc++',
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
           },
@@ -100,9 +97,7 @@
       'targets': [
         {
           'target_name': 'pty',
-          'cflags!': [ '-fno-exceptions' ],
-          'cflags_cc!': [ '-fno-exceptions' ],
-          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+          'xcode_settings': {
             'CLANG_CXX_LIBRARY': 'libc++',
             'MACOSX_DEPLOYMENT_TARGET': '10.7',
           },

--- a/binding.gyp
+++ b/binding.gyp
@@ -31,16 +31,6 @@
       'targets': [
         {
           'target_name': 'conpty',
-          'xcode_settings': {
-            'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
-          },
-          'msvs_settings': {
-            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-          },
-          'include_dirs' : [
-            '<!(node -p "require(\'node-addon-api\').include_dir")'
-          ],
           'sources' : [
             'src/win/conpty.cc',
             'src/win/path_util.cc'
@@ -51,29 +41,12 @@
         },
         {
           'target_name': 'conpty_console_list',
-          'xcode_settings': {
-            'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
-          },
-          'msvs_settings': {
-            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-          },
-          'include_dirs' : [
-            '<!(node -p "require(\'node-addon-api\').include_dir")'
-          ],
           'sources' : [
             'src/win/conpty_console_list.cc'
           ],
         },
         {
           'target_name': 'pty',
-          'xcode_settings': {
-            'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
-          },
-          'msvs_settings': {
-            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-          },
           'include_dirs' : [
             '<!(node -p "require(\'node-addon-api\').include_dir")',
             'deps/winpty/src/include',
@@ -97,16 +70,6 @@
       'targets': [
         {
           'target_name': 'pty',
-          'xcode_settings': {
-            'CLANG_CXX_LIBRARY': 'libc++',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7',
-          },
-          'msvs_settings': {
-            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
-          },
-          'include_dirs' : [
-            '<!(node -p "require(\'node-addon-api\').include_dir")'
-          ],
           'sources': [
             'src/unix/pty.cc',
           ],
@@ -122,13 +85,6 @@
               'libraries!': [
                 '-lutil'
               ]
-            }],
-            ['OS=="mac"', {
-              "cflags+": ["-fvisibility=hidden"],
-              "xcode_settings": {
-                "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
-                "MACOSX_DEPLOYMENT_TARGET":"10.7"
-              }
             }]
           ]
         }
@@ -142,9 +98,7 @@
           'sources': [
             'src/unix/spawn-helper.cc',
           ],
-          "cflags+": ["-fvisibility=hidden"],
           "xcode_settings": {
-            "GCC_SYMBOLS_PRIVATE_EXTERN": "YES",
             "MACOSX_DEPLOYMENT_TARGET":"10.7"
           }
         },

--- a/binding.gyp
+++ b/binding.gyp
@@ -28,8 +28,17 @@
       'targets': [
         {
           'target_name': 'conpty',
+          'cflags!': [ '-fno-exceptions' ],
+          'cflags_cc!': [ '-fno-exceptions' ],
+          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+          },
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+          },
           'include_dirs' : [
-            '<!(node -e "require(\'nan\')")'
+            '<!(node -p "require(\'node-addon-api\').include_dir")'
           ],
           'sources' : [
             'src/win/conpty.cc',
@@ -41,8 +50,17 @@
         },
         {
           'target_name': 'conpty_console_list',
+          'cflags!': [ '-fno-exceptions' ],
+          'cflags_cc!': [ '-fno-exceptions' ],
+          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+          },
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+          },
           'include_dirs' : [
-            '<!(node -e "require(\'nan\')")'
+            '<!(node -p "require(\'node-addon-api\').include_dir")'
           ],
           'sources' : [
             'src/win/conpty_console_list.cc'
@@ -50,8 +68,17 @@
         },
         {
           'target_name': 'pty',
+          'cflags!': [ '-fno-exceptions' ],
+          'cflags_cc!': [ '-fno-exceptions' ],
+          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+          },
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+          },
           'include_dirs' : [
-            '<!(node -e "require(\'nan\')")',
+            '<!(node -p "require(\'node-addon-api\').include_dir")',
             'deps/winpty/src/include',
           ],
           # Disabled due to winpty
@@ -73,8 +100,17 @@
       'targets': [
         {
           'target_name': 'pty',
+          'cflags!': [ '-fno-exceptions' ],
+          'cflags_cc!': [ '-fno-exceptions' ],
+          'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'CLANG_CXX_LIBRARY': 'libc++',
+            'MACOSX_DEPLOYMENT_TARGET': '10.7',
+          },
+          'msvs_settings': {
+            'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+          },
           'include_dirs' : [
-            '<!(node -e "require(\'nan\')")'
+            '<!(node -p "require(\'node-addon-api\').include_dir")'
           ],
           'sources': [
             'src/unix/pty.cc',
@@ -93,7 +129,9 @@
               ]
             }],
             ['OS=="mac"', {
+              "cflags+": ["-fvisibility=hidden"],
               "xcode_settings": {
+                "GCC_SYMBOLS_PRIVATE_EXTERN": "YES", # -fvisibility=hidden
                 "MACOSX_DEPLOYMENT_TARGET":"10.7"
               }
             }]
@@ -109,7 +147,9 @@
           'sources': [
             'src/unix/spawn-helper.cc',
           ],
+          "cflags+": ["-fvisibility=hidden"],
           "xcode_settings": {
+            "GCC_SYMBOLS_PRIVATE_EXTERN": "YES",
             "MACOSX_DEPLOYMENT_TARGET":"10.7"
           }
         },

--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "node-addon-api": "^7.0.0",
-    "node-api-headers": "^1.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
@@ -55,6 +53,8 @@
     "eslint": "^6.8.0",
     "mocha": "10",
     "node-gyp": "^9.4.0",
+    "node-addon-api": "^7.0.0",
+    "node-api-headers": "^1.1.0",
     "ps-list": "^6.0.0",
     "typescript": "^3.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "node-addon-api": "^7.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",
@@ -53,8 +54,6 @@
     "eslint": "^6.8.0",
     "mocha": "10",
     "node-gyp": "^9.4.0",
-    "node-addon-api": "^7.0.0",
-    "node-api-headers": "^1.1.0",
     "ps-list": "^6.0.0",
     "typescript": "^3.8.3"
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "nan": "^2.17.0"
+    "node-addon-api": "^7.0.0",
+    "node-api-headers": "^1.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^7.0.2",

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -772,7 +772,6 @@ done:
  */
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
   exports.Set("fork",    Napi::Function::New(env, PtyFork));
   exports.Set("open",    Napi::Function::New(env, PtyOpen));
   exports.Set("resize",  Napi::Function::New(env, PtyResize));

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -17,11 +17,14 @@
  * Includes
  */
 
-#include <nan.h>
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <assert.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <thread>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -99,27 +102,106 @@ int pthread_fchdir_np(int fd) API_AVAILABLE(macosx(10.12));
 })
 #endif
 
-/**
- * Structs
- */
+void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
+  struct ExitEvent {
+    int exit_code = 0, signal_code = 0;
+  };
+  std::thread *th = new std::thread;
+  // Don't use Napi::AsyncWorker which is limited by UV_THREADPOOL_SIZE.
+  auto tsfn = Napi::ThreadSafeFunction::New(
+      env,
+      cb,                           // JavaScript function called asynchronously
+      "SetupExitCallback_resource", // Name
+      0,                            // Unlimited queue
+      1,                            // Only one thread will use this initially
+      [th](Napi::Env) {   // Finalizer used to clean threads up
+        th->join();
+        delete th;
+      });
+  *th = std::thread([tsfn = std::move(tsfn), pid] {
+    auto callback = [](Napi::Env env, Napi::Function cb, ExitEvent *exit_event) {
+      cb.Call({Napi::Number::New(env, exit_event->exit_code),
+               Napi::Number::New(env, exit_event->signal_code)});
+      delete exit_event;
+    };
 
-struct pty_baton {
-  Nan::Persistent<v8::Function> cb;
-  int exit_code;
-  int signal_code;
-  pid_t pid;
-  uv_async_t async;
-  uv_thread_t tid;
-};
+    int ret;
+    int stat_loc;
+#if defined(__APPLE__)
+    // Based on
+    // https://source.chromium.org/chromium/chromium/src/+/main:base/process/kill_mac.cc;l=35-69?
+    int kq = HANDLE_EINTR(kqueue());
+    struct kevent change = {0};
+    EV_SET(&change, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
+    ret = HANDLE_EINTR(kevent(kq, &change, 1, NULL, 0, NULL));
+    if (ret == -1) {
+      if (errno == ESRCH) {
+        // At this point, one of the following has occurred:
+        // 1. The process has died but has not yet been reaped.
+        // 2. The process has died and has already been reaped.
+        // 3. The process is in the process of dying. It's no longer
+        //    kqueueable, but it may not be waitable yet either. Mark calls
+        //    this case the "zombie death race".
+        ret = HANDLE_EINTR(waitpid(pid, &stat_loc, WNOHANG));
+        if (ret == 0) {
+          ret = kill(pid, SIGKILL);
+          if (ret != -1) {
+            HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+          }
+        }
+      }
+    } else {
+      struct kevent event = {0};
+      ret = HANDLE_EINTR(kevent(kq, NULL, 0, &event, 1, NULL));
+      if (ret == 1) {
+        if ((event.fflags & NOTE_EXIT) &&
+            (event.ident == static_cast<uintptr_t>(pid))) {
+          // The process is dead or dying. This won't block for long, if at
+          // all.
+          HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+        }
+      }
+    }
+#else
+    while (true) {
+      errno = 0;
+      if ((ret = waitpid(pid, &stat_loc, 0)) != pid) {
+        if (ret == -1 && errno == EINTR) {
+          continue;
+        }
+        if (ret == -1 && errno == ECHILD) {
+          // XXX node v0.8.x seems to have this problem.
+          // waitpid is already handled elsewhere.
+          ;
+        } else {
+          assert(false);
+        }
+      }
+      break;
+    }
+#endif
+    ExitEvent *exit_event = new ExitEvent;
+    if (WIFEXITED(stat_loc)) {
+      exit_event->exit_code = WEXITSTATUS(stat_loc); // errno?
+    }
+    if (WIFSIGNALED(stat_loc)) {
+      exit_event->signal_code = WTERMSIG(stat_loc);
+    }
+    auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+    assert(status == napi_ok);
+
+    tsfn.Release();
+  });
+}
 
 /**
  * Methods
  */
 
-NAN_METHOD(PtyFork);
-NAN_METHOD(PtyOpen);
-NAN_METHOD(PtyResize);
-NAN_METHOD(PtyGetProc);
+Napi::Value PtyFork(const Napi::CallbackInfo& info);
+Napi::Value PtyOpen(const Napi::CallbackInfo& info);
+Napi::Value PtyResize(const Napi::CallbackInfo& info);
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info);
 
 /**
  * Functions
@@ -136,15 +218,6 @@ static char *
 pty_getproc(int, char *);
 #endif
 
-static void
-pty_waitpid(void *);
-
-static void
-pty_after_waitpid(uv_async_t *);
-
-static void
-pty_after_close(uv_handle_t *);
-
 #if defined(__APPLE__) || defined(__OpenBSD__)
 static void
 pty_posix_spawn(char** argv, char** env,
@@ -155,62 +228,63 @@ pty_posix_spawn(char** argv, char** env,
                 int* err);
 #endif
 
-NAN_METHOD(PtyFork) {
-  Nan::HandleScope scope;
+Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+  Napi::Env napiEnv(info.Env());
+  Napi::HandleScope scope(napiEnv);
 
   if (info.Length() != 11 ||
-      !info[0]->IsString() ||
-      !info[1]->IsArray() ||
-      !info[2]->IsArray() ||
-      !info[3]->IsString() ||
-      !info[4]->IsNumber() ||
-      !info[5]->IsNumber() ||
-      !info[6]->IsNumber() ||
-      !info[7]->IsNumber() ||
-      !info[8]->IsBoolean() ||
-      !info[9]->IsString() ||
-      !info[10]->IsFunction()) {
-    return Nan::ThrowError(
-        "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, helperPath, onexit)");
+      !info[0].IsString() ||
+      !info[1].IsArray() ||
+      !info[2].IsArray() ||
+      !info[3].IsString() ||
+      !info[4].IsNumber() ||
+      !info[5].IsNumber() ||
+      !info[6].IsNumber() ||
+      !info[7].IsNumber() ||
+      !info[8].IsBoolean() ||
+      !info[9].IsString() ||
+      !info[10].IsFunction()) {
+    Napi::Error::New(napiEnv, "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, onexit)").ThrowAsJavaScriptException();
+    return napiEnv.Undefined();
   }
 
   // file
-  Nan::Utf8String file(info[0]);
+  std::string file = info[0].As<Napi::String>();
 
   // args
-  v8::Local<v8::Array> argv_ = v8::Local<v8::Array>::Cast(info[1]);
+  Napi::Array argv_ = info[1].As<Napi::Array>();
 
   // env
-  v8::Local<v8::Array> env_ = v8::Local<v8::Array>::Cast(info[2]);
-  int envc = env_->Length();
+  Napi::Array env_ = info[2].As<Napi::Array>();
+  int envc = env_.Length();
   char **env = new char*[envc+1];
   env[envc] = NULL;
   for (int i = 0; i < envc; i++) {
-    Nan::Utf8String pair(Nan::Get(env_, i).ToLocalChecked());
-    env[i] = strdup(*pair);
+    std::string pair = env_.Get(i).As<Napi::String>();
+    env[i] = strdup(pair.c_str());
   }
 
   // cwd
-  Nan::Utf8String cwd_(info[3]);
+  std::string cwd_ = info[3].As<Napi::String>();
 
   // size
   struct winsize winp;
-  winp.ws_col = info[4]->IntegerValue(Nan::GetCurrentContext()).FromJust();
-  winp.ws_row = info[5]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  winp.ws_col = info[4].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[5].As<Napi::Number>().Int32Value();
   winp.ws_xpixel = 0;
   winp.ws_ypixel = 0;
 
 #if !defined(__APPLE__)
   // uid / gid
-  int uid = info[6]->IntegerValue(Nan::GetCurrentContext()).FromJust();
-  int gid = info[7]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  int uid = info[6].As<Napi::Number>().Int32Value();
+  int gid = info[7].As<Napi::Number>().Int32Value();
 #endif
 
   // termios
   struct termios t = termios();
   struct termios *term = &t;
   term->c_iflag = ICRNL | IXON | IXANY | IMAXBEL | BRKINT;
-  if (Nan::To<bool>(info[8]).FromJust()) {
+  if (info[8].As<Napi::Boolean>().Value()) {
 #if defined(IUTF8)
     term->c_iflag |= IUTF8;
 #endif
@@ -245,45 +319,45 @@ NAN_METHOD(PtyFork) {
   cfsetospeed(term, B38400);
 
   // helperPath
-  Nan::Utf8String helper_path(info[9]);
+  std::string helper_path = info[9].As<Napi::String>();
 
   pid_t pid;
   int master;
 #if defined(__APPLE__)
-  int argc = argv_->Length();
+  int argc = argv_.Length();
   int argl = argc + 4;
   char **argv = new char*[argl];
-  argv[0] = strdup(*helper_path);
-  argv[1] = strdup(*cwd_);
-  argv[2] = strdup(*file);
+  argv[0] = strdup(helper_path.c_str());
+  argv[1] = strdup(cwd_.c_str());
+  argv[2] = strdup(file.c_str());
   argv[argl - 1] = NULL;
   for (int i = 0; i < argc; i++) {
-    Nan::Utf8String arg(Nan::Get(argv_, i).ToLocalChecked());
-    argv[i + 3] = strdup(*arg);
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 3] = strdup(arg.c_str());
   }
 
   int err = -1;
   pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
   if (err != 0) {
-    Nan::ThrowError("posix_spawnp failed.");
+    Napi::Error::New(napiEnv, "posix_spawnp failed.").ThrowAsJavaScriptException();
     goto done;
   }
   if (pty_nonblock(master) == -1) {
-    Nan::ThrowError("Could not set master fd to nonblocking.");
+    Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.").ThrowAsJavaScriptException();
     goto done;
   }
 #else
-  int argc = argv_->Length();
+  int argc = argv_.Length();
   int argl = argc + 2;
   char **argv = new char*[argl];
-  argv[0] = strdup(*file);
+  argv[0] = strdup(file.c_str());
   argv[argl - 1] = NULL;
   for (int i = 0; i < argc; i++) {
-    Nan::Utf8String arg(Nan::Get(argv_, i).ToLocalChecked());
-    argv[i + 1] = strdup(*arg);
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 1] = strdup(arg.c_str());
   }
 
-  char* cwd = strdup(*cwd_);
+  char* cwd = strdup(cwd_.c_str());
   sigset_t newmask, oldmask;
   struct sigaction sig_action;
   // temporarily block all signals
@@ -318,7 +392,7 @@ NAN_METHOD(PtyFork) {
 
   switch (pid) {
     case -1:
-      Nan::ThrowError("forkpty(3) failed.");
+      Napi::Error::New(napiEnv, "forkpty(3) failed.").ThrowAsJavaScriptException();
       goto done;
     case 0:
       if (strlen(cwd)) {
@@ -349,36 +423,26 @@ NAN_METHOD(PtyFork) {
       }
     default:
       if (pty_nonblock(master) == -1) {
-        Nan::ThrowError("Could not set master fd to nonblocking.");
+        Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.").ThrowAsJavaScriptException();
         goto done;
       }
   }
 #endif
 
   {
-    v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-    Nan::Set(obj,
-      Nan::New<v8::String>("fd").ToLocalChecked(),
-      Nan::New<v8::Number>(master));
-    Nan::Set(obj,
-      Nan::New<v8::String>("pid").ToLocalChecked(),
-      Nan::New<v8::Number>(pid));
-    Nan::Set(obj,
-      Nan::New<v8::String>("pty").ToLocalChecked(),
-      Nan::New<v8::String>(ptsname(master)).ToLocalChecked());
+    Napi::Object obj = Napi::Object::New(napiEnv);
+    (obj).Set(Napi::String::New(napiEnv, "fd"),
+      Napi::Number::New(napiEnv, master));
+    (obj).Set(Napi::String::New(napiEnv, "pid"),
+      Napi::Number::New(napiEnv, pid));
+    (obj).Set(Napi::String::New(napiEnv, "pty"),
+      Napi::String::New(napiEnv, ptsname(master)));
 
-    pty_baton *baton = new pty_baton();
-    baton->exit_code = 0;
-    baton->signal_code = 0;
-    baton->cb.Reset(v8::Local<v8::Function>::Cast(info[10]));
-    baton->pid = pid;
-    baton->async.data = baton;
+    // Set up process exit callback.
+    Napi::Function cb = info[10].As<Napi::Function>();
+    SetupExitCallback(napiEnv, cb, pid);
 
-    uv_async_init(uv_default_loop(), &baton->async, pty_after_waitpid);
-
-    uv_thread_create(&baton->tid, pty_waitpid, static_cast<void*>(baton));
-
-    return info.GetReturnValue().Set(obj);
+    return obj;
   }
 
 done:
@@ -389,22 +453,24 @@ done:
   for (int i = 0; i < envc; i++) free(env[i]);
   delete[] env;
 #endif
-  return info.GetReturnValue().SetUndefined();
+  return napiEnv.Undefined();
 }
 
-NAN_METHOD(PtyOpen) {
-  Nan::HandleScope scope;
+Napi::Value PtyOpen(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 2 ||
-      !info[0]->IsNumber() ||
-      !info[1]->IsNumber()) {
-    return Nan::ThrowError("Usage: pty.open(cols, rows)");
+      !info[0].IsNumber() ||
+      !info[1].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.open(cols, rows)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   // size
   struct winsize winp;
-  winp.ws_col = info[0]->IntegerValue(Nan::GetCurrentContext()).FromJust();
-  winp.ws_row = info[1]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  winp.ws_col = info[0].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[1].As<Napi::Number>().Int32Value();
   winp.ws_xpixel = 0;
   winp.ws_ypixel = 0;
 
@@ -413,98 +479,108 @@ NAN_METHOD(PtyOpen) {
   int ret = openpty(&master, &slave, nullptr, NULL, static_cast<winsize*>(&winp));
 
   if (ret == -1) {
-    return Nan::ThrowError("openpty(3) failed.");
+    Napi::Error::New(env, "openpty(3) failed.").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   if (pty_nonblock(master) == -1) {
-    return Nan::ThrowError("Could not set master fd to nonblocking.");
+    Napi::Error::New(env, "Could not set master fd to nonblocking.").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   if (pty_nonblock(slave) == -1) {
-    return Nan::ThrowError("Could not set slave fd to nonblocking.");
+    Napi::Error::New(env, "Could not set slave fd to nonblocking.").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-  Nan::Set(obj,
-    Nan::New<v8::String>("master").ToLocalChecked(),
-    Nan::New<v8::Number>(master));
-  Nan::Set(obj,
-    Nan::New<v8::String>("slave").ToLocalChecked(),
-    Nan::New<v8::Number>(slave));
-  Nan::Set(obj,
-    Nan::New<v8::String>("pty").ToLocalChecked(),
-    Nan::New<v8::String>(ptsname(master)).ToLocalChecked());
+  Napi::Object obj = Napi::Object::New(env);
+  (obj).Set(Napi::String::New(env, "master"),
+    Napi::Number::New(env, master));
+  (obj).Set(Napi::String::New(env, "slave"),
+    Napi::Number::New(env, slave));
+  (obj).Set(Napi::String::New(env, "pty"),
+    Napi::String::New(env, ptsname(master)));
 
-  return info.GetReturnValue().Set(obj);
+  return obj;
 }
 
-NAN_METHOD(PtyResize) {
-  Nan::HandleScope scope;
+Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 3 ||
-      !info[0]->IsNumber() ||
-      !info[1]->IsNumber() ||
-      !info[2]->IsNumber()) {
-    return Nan::ThrowError("Usage: pty.resize(fd, cols, rows)");
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.resize(fd, cols, rows)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  int fd = info[0]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  int fd = info[0].As<Napi::Number>().Int32Value();
 
   struct winsize winp;
-  winp.ws_col = info[1]->IntegerValue(Nan::GetCurrentContext()).FromJust();
-  winp.ws_row = info[2]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  winp.ws_col = info[1].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[2].As<Napi::Number>().Int32Value();
   winp.ws_xpixel = 0;
   winp.ws_ypixel = 0;
 
   if (ioctl(fd, TIOCSWINSZ, &winp) == -1) {
     switch (errno) {
-      case EBADF: return Nan::ThrowError("ioctl(2) failed, EBADF");
-      case EFAULT: return Nan::ThrowError("ioctl(2) failed, EFAULT");
-      case EINVAL: return Nan::ThrowError("ioctl(2) failed, EINVAL");
-      case ENOTTY: return Nan::ThrowError("ioctl(2) failed, ENOTTY");
+      case EBADF:  Napi::Error::New(env, "ioctl(2) failed, EBADF").ThrowAsJavaScriptException();
+                   return env.Undefined();
+      case EFAULT: Napi::Error::New(env, "ioctl(2) failed, EFAULT").ThrowAsJavaScriptException();
+                   return env.Undefined();
+      case EINVAL: Napi::Error::New(env, "ioctl(2) failed, EINVAL").ThrowAsJavaScriptException();
+                   return env.Undefined();
+      case ENOTTY: Napi::Error::New(env, "ioctl(2) failed, ENOTTY").ThrowAsJavaScriptException();
+                   return env.Undefined();
     }
-    return Nan::ThrowError("ioctl(2) failed");
+    Napi::Error::New(env, "ioctl(2) failed").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  return info.GetReturnValue().SetUndefined();
+  return env.Undefined();
 }
 
 /**
  * Foreground Process Name
  */
-NAN_METHOD(PtyGetProc) {
-  Nan::HandleScope scope;
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
 #if defined(__APPLE__)
   if (info.Length() != 1 ||
-      !info[0]->IsNumber()) {
-    return Nan::ThrowError("Usage: pty.process(pid)");
+      !info[0].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.process(pid)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  int fd = info[0]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  int fd = info[0].As<Napi::Number>().Int32Value();
   char *name = pty_getproc(fd);
 #else
   if (info.Length() != 2 ||
-      !info[0]->IsNumber() ||
-      !info[1]->IsString()) {
-    return Nan::ThrowError("Usage: pty.process(fd, tty)");
+      !info[0].IsNumber() ||
+      !info[1].IsString()) {
+    Napi::Error::New(env, "Usage: pty.process(fd, tty)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  int fd = info[0]->IntegerValue(Nan::GetCurrentContext()).FromJust();
+  int fd = info[0].As<Napi::Number>().Int32Value();
 
-  Nan::Utf8String tty_(info[1]);
-  char *tty = strdup(*tty_);
+  std::string tty_ = info[1].As<Napi::String>();
+  char *tty = strdup(tty_.c_str());
   char *name = pty_getproc(fd, tty);
   free(tty);
 #endif
 
   if (name == NULL) {
-    return info.GetReturnValue().SetUndefined();
+    return env.Undefined();
   }
 
-  v8::Local<v8::String> name_ = Nan::New<v8::String>(name).ToLocalChecked();
+  Napi::String name_ = Napi::String::New(env, name);
   free(name);
-  return info.GetReturnValue().Set(name_);
+  return name_;
 }
 
 /**
@@ -516,114 +592,6 @@ pty_nonblock(int fd) {
   int flags = fcntl(fd, F_GETFL, 0);
   if (flags == -1) return -1;
   return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-}
-
-/**
- * pty_waitpid
- * Wait for SIGCHLD to read exit status.
- */
-
-static void
-pty_waitpid(void *data) {
-  int ret;
-  int stat_loc;
-  pty_baton *baton = static_cast<pty_baton*>(data);
-  errno = 0;
-#if defined(__APPLE__)
-  // Based on
-  // https://source.chromium.org/chromium/chromium/src/+/main:base/process/kill_mac.cc;l=35-69?
-  int kq = HANDLE_EINTR(kqueue());
-  struct kevent change = {0};
-  EV_SET(&change, baton->pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
-  ret = HANDLE_EINTR(kevent(kq, &change, 1, NULL, 0, NULL));
-  if (ret == -1) {
-    if (errno == ESRCH) {
-      // At this point, one of the following has occurred:
-      // 1. The process has died but has not yet been reaped.
-      // 2. The process has died and has already been reaped.
-      // 3. The process is in the process of dying. It's no longer
-      //    kqueueable, but it may not be waitable yet either. Mark calls
-      //    this case the "zombie death race".
-      ret = HANDLE_EINTR(waitpid(baton->pid, &stat_loc, WNOHANG));
-      if (ret == 0) {
-        ret = kill(baton->pid, SIGKILL);
-        if (ret != -1) {
-          HANDLE_EINTR(waitpid(baton->pid, &stat_loc, 0));
-        }
-      }
-    }
-  } else {
-    struct kevent event = {0};
-    ret = HANDLE_EINTR(kevent(kq, NULL, 0, &event, 1, NULL));
-    if (ret == 1) {
-      if ((event.fflags & NOTE_EXIT) &&
-          (event.ident == static_cast<uintptr_t>(baton->pid))) {
-        // The process is dead or dying. This won't block for long, if at
-        // all.
-        HANDLE_EINTR(waitpid(baton->pid, &stat_loc, 0));
-      }
-    }
-  }
-#else
-  if ((ret = waitpid(baton->pid, &stat_loc, 0)) != baton->pid) {
-    if (ret == -1 && errno == EINTR) {
-      return pty_waitpid(baton);
-    }
-    if (ret == -1 && errno == ECHILD) {
-      // XXX node v0.8.x seems to have this problem.
-      // waitpid is already handled elsewhere.
-      ;
-    } else {
-      assert(false);
-    }
-  }
-#endif
-
-  if (WIFEXITED(stat_loc)) {
-    baton->exit_code = WEXITSTATUS(stat_loc); // errno?
-  }
-
-  if (WIFSIGNALED(stat_loc)) {
-    baton->signal_code = WTERMSIG(stat_loc);
-  }
-
-  uv_async_send(&baton->async);
-}
-
-/**
- * pty_after_waitpid
- * Callback after exit status has been read.
- */
-
-static void
-pty_after_waitpid(uv_async_t *async) {
-  Nan::HandleScope scope;
-  pty_baton *baton = static_cast<pty_baton*>(async->data);
-
-  v8::Local<v8::Value> argv[] = {
-    Nan::New<v8::Integer>(baton->exit_code),
-    Nan::New<v8::Integer>(baton->signal_code),
-  };
-
-  v8::Local<v8::Function> cb = Nan::New<v8::Function>(baton->cb);
-  baton->cb.Reset();
-  memset(&baton->cb, -1, sizeof(baton->cb));
-  Nan::AsyncResource resource("pty_after_waitpid");
-  resource.runInAsyncScope(Nan::GetCurrentContext()->Global(), cb, 2, argv);
-
-  uv_close((uv_handle_t *)async, pty_after_close);
-}
-
-/**
- * pty_after_close
- * uv_close() callback - free handle data
- */
-
-static void
-pty_after_close(uv_handle_t *handle) {
-  uv_async_t *async = (uv_async_t *)handle;
-  pty_baton *baton = static_cast<pty_baton*>(async->data);
-  delete baton;
 }
 
 /**
@@ -828,12 +796,14 @@ done:
  * Init
  */
 
-NAN_MODULE_INIT(init) {
-  Nan::HandleScope scope;
-  Nan::Export(target, "fork", PtyFork);
-  Nan::Export(target, "open", PtyOpen);
-  Nan::Export(target, "resize", PtyResize);
-  Nan::Export(target, "process", PtyGetProc);
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  exports.Set(Napi::String::New(env, "fork"),    Napi::Function::New(env, PtyFork));
+  exports.Set(Napi::String::New(env, "open"),    Napi::Function::New(env, PtyOpen));
+  exports.Set(Napi::String::New(env, "resize"),  Napi::Function::New(env, PtyResize));
+  exports.Set(Napi::String::New(env, "process"), Napi::Function::New(env, PtyGetProc));
+  return exports;
 }
 
-NODE_MODULE(pty, init)
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -244,7 +244,7 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info) {
       !info[8].IsBoolean() ||
       !info[9].IsString() ||
       !info[10].IsFunction()) {
-    Napi::Error::New(napiEnv, "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, onexit)").ThrowAsJavaScriptException();
+    Napi::Error::New(napiEnv, "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, helperPath, onexit)").ThrowAsJavaScriptException();
     return napiEnv.Undefined();
   }
 

--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -102,6 +102,18 @@ static pty_baton* get_pty_baton(int id) {
   return nullptr;
 }
 
+static bool remove_pty_baton(int id) {
+  for (size_t i = 0; i < ptyHandles.size(); ++i) {
+    pty_baton* ptyHandle = ptyHandles[i];
+    if (ptyHandle->id == id) {
+      ptyHandles.erase(ptyHandles.begin() + i);
+      ptyHandle = nullptr;
+      return true;
+    }
+  }
+  return false;
+}
+
 Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
   std::stringstream errorText;
   errorText << text;
@@ -464,6 +476,7 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
     }
 
     CloseHandle(handle->hShell);
+    assert(remove_pty_baton(id));
   }
 
   return env.Undefined();
@@ -474,7 +487,6 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
 */
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
   exports.Set("startProcess", Napi::Function::New(env, PtyStartProcess));
   exports.Set("connect", Napi::Function::New(env, PtyConnect));
   exports.Set("resize", Napi::Function::New(env, PtyResize));

--- a/src/win/conpty_console_list.cc
+++ b/src/win/conpty_console_list.cc
@@ -2,23 +2,25 @@
  * Copyright (c) 2019, Microsoft Corporation (MIT License).
  */
 
-#include <nan.h>
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
 #include <windows.h>
 
-static NAN_METHOD(ApiConsoleProcessList) {
+static Napi::Value ApiConsoleProcessList(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
   if (info.Length() != 1 ||
-      !info[0]->IsNumber()) {
-    Nan::ThrowError("Usage: getConsoleProcessList(shellPid)");
-    return;
+      !info[0].IsNumber()) {
+    Napi::Error::New(env, "Usage: getConsoleProcessList(shellPid)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  const DWORD pid = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
+  const DWORD pid = info[0].As<Napi::Number>().Uint32Value();
 
   if (!FreeConsole()) {
-    Nan::ThrowError("FreeConsole failed");
+    Napi::Error::New(env, "FreeConsole failed").ThrowAsJavaScriptException();
   }
   if (!AttachConsole(pid)) {
-    Nan::ThrowError("AttachConsole failed");
+    Napi::Error::New(env, "AttachConsole failed").ThrowAsJavaScriptException();
   }
   auto processList = std::vector<DWORD>(64);
   auto processCount = GetConsoleProcessList(&processList[0], static_cast<DWORD>(processList.size()));
@@ -28,16 +30,17 @@ static NAN_METHOD(ApiConsoleProcessList) {
   }
   FreeConsole();
 
-  v8::Local<v8::Array> result = Nan::New<v8::Array>();
+  Napi::Array result = Napi::Array::New(env);
   for (DWORD i = 0; i < processCount; i++) {
-    Nan::Set(result, i, Nan::New<v8::Number>(processList[i]));
+    result.Set(i, Napi::Number::New(env, processList[i]));
   }
-  info.GetReturnValue().Set(result);
+  return result;
 }
 
-extern "C" void init(v8::Local<v8::Object> target) {
-  Nan::HandleScope scope;
-  Nan::SetMethod(target, "getConsoleProcessList", ApiConsoleProcessList);
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  exports.Set(Napi::String::New(env, "getConsoleProcessList"), Napi::Function::New(env, ApiConsoleProcessList));
+  return exports;
 };
 
-NODE_MODULE(pty, init);
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/src/win/conpty_console_list.cc
+++ b/src/win/conpty_console_list.cc
@@ -10,17 +10,16 @@ static Napi::Value ApiConsoleProcessList(const Napi::CallbackInfo& info) {
   Napi::Env env(info.Env());
   if (info.Length() != 1 ||
       !info[0].IsNumber()) {
-    Napi::Error::New(env, "Usage: getConsoleProcessList(shellPid)").ThrowAsJavaScriptException();
-    return env.Undefined();
+    throw Napi::Error::New(env, "Usage: getConsoleProcessList(shellPid)");
   }
 
   const DWORD pid = info[0].As<Napi::Number>().Uint32Value();
 
   if (!FreeConsole()) {
-    Napi::Error::New(env, "FreeConsole failed").ThrowAsJavaScriptException();
+    throw Napi::Error::New(env, "FreeConsole failed");
   }
   if (!AttachConsole(pid)) {
-    Napi::Error::New(env, "AttachConsole failed").ThrowAsJavaScriptException();
+    throw Napi::Error::New(env, "AttachConsole failed");
   }
   auto processList = std::vector<DWORD>(64);
   auto processCount = GetConsoleProcessList(&processList[0], static_cast<DWORD>(processList.size()));
@@ -39,7 +38,7 @@ static Napi::Value ApiConsoleProcessList(const Napi::CallbackInfo& info) {
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
-  exports.Set(Napi::String::New(env, "getConsoleProcessList"), Napi::Function::New(env, ApiConsoleProcessList));
+  exports.Set("getConsoleProcessList", Napi::Function::New(env, ApiConsoleProcessList));
   return exports;
 };
 

--- a/src/win/conpty_console_list.cc
+++ b/src/win/conpty_console_list.cc
@@ -37,7 +37,6 @@ static Napi::Value ApiConsoleProcessList(const Napi::CallbackInfo& info) {
 }
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
   exports.Set("getConsoleProcessList", Napi::Function::New(env, ApiConsoleProcessList));
   return exports;
 };

--- a/src/win/path_util.cc
+++ b/src/win/path_util.cc
@@ -4,8 +4,9 @@
  * Copyright (c) 2018, Microsoft Corporation (MIT License).
  */
 
+#include <stdexcept>
 #include <Shlwapi.h> // PathCombine
-
+#include <Windows.h>
 #include "path_util.h"
 
 namespace path_util {

--- a/src/win/path_util.cc
+++ b/src/win/path_util.cc
@@ -4,25 +4,28 @@
  * Copyright (c) 2018, Microsoft Corporation (MIT License).
  */
 
-#include <nan.h>
 #include <Shlwapi.h> // PathCombine
 
 #include "path_util.h"
 
 namespace path_util {
 
-const wchar_t* to_wstring(const Nan::Utf8String& str) {
-  const char *bytes = *str;
-  int sizeOfStr = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, NULL, 0);
-  if (sizeOfStr <= 0) {
-    return L"";
+std::wstring to_wstring(const Napi::String& str) {
+  const std::u16string & u16 = str.Utf16Value();
+  return std::wstring(u16.begin(), u16.end());
+}
+
+std::string wstring_to_string(const std::wstring &wide_string) {
+  if (wide_string.empty()) {
+    return "";
   }
-  wchar_t *output = new wchar_t[sizeOfStr];
-  int status = MultiByteToWideChar(CP_UTF8, 0, bytes, -1, output, sizeOfStr);
-  if (status == 0) {
-    return L"";
+  const auto size_needed = WideCharToMultiByte(CP_UTF8, 0, &wide_string.at(0), (int)wide_string.size(), nullptr, 0, nullptr, nullptr);
+  if (size_needed <= 0) {
+    return "";
   }
-  return output;
+  std::string result(size_needed, 0);
+  WideCharToMultiByte(CP_UTF8, 0, &wide_string.at(0), (int)wide_string.size(), &result.at(0), size_needed, nullptr, nullptr);
+  return result;
 }
 
 const char* from_wstring(const wchar_t* wstr) {

--- a/src/win/path_util.h
+++ b/src/win/path_util.h
@@ -7,13 +7,18 @@
 #ifndef NODE_PTY_PATH_UTIL_H_
 #define NODE_PTY_PATH_UTIL_H_
 
-#include <nan.h>
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <string>
+#include <stdexcept>
+#include <Windows.h>
 
 #define MAX_ENV 65536
 
 namespace path_util {
 
-const wchar_t* to_wstring(const Nan::Utf8String& str);
+std::wstring to_wstring(const Napi::String& str);
+std::string wstring_to_string(const std::wstring &wide_string);
 const char* from_wstring(const wchar_t* wstr);
 bool file_exists(std::wstring filename);
 std::wstring get_shell_path(std::wstring filename);

--- a/src/win/path_util.h
+++ b/src/win/path_util.h
@@ -10,8 +10,6 @@
 #define NODE_ADDON_API_DISABLE_DEPRECATED
 #include <napi.h>
 #include <string>
-#include <stdexcept>
-#include <Windows.h>
 
 #define MAX_ENV 65536
 

--- a/src/win/winpty.cc
+++ b/src/win/winpty.cc
@@ -8,9 +8,11 @@
  *   with pseudo-terminal file descriptors.
  */
 
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
 #include <iostream>
+#include <assert.h>
 #include <map>
-#include <nan.h>
 #include <Shlwapi.h> // PathCombine, PathIsRelative
 #include <sstream>
 #include <stdlib.h>
@@ -24,8 +26,6 @@
 /**
 * Misc
 */
-extern "C" void init(v8::Local<v8::Object>);
-
 #define WINPTY_DBG_VARIABLE TEXT("WINPTYDBG")
 
 /**
@@ -66,28 +66,29 @@ static bool remove_pipe_handle(DWORD pid) {
   return false;
 }
 
-void throw_winpty_error(const char *generalMsg, winpty_error_ptr_t error_ptr) {
-  std::wstringstream why;
-  std::wstring msg(winpty_error_msg(error_ptr));
-  why << generalMsg << ": " << msg;
-  Nan::ThrowError(path_util::from_wstring(why.str().c_str()));
+void throw_winpty_error(const char *generalMsg, winpty_error_ptr_t error_ptr, Napi::Env env) {
+  std::string why;
+  why += generalMsg;
+  why += ": ";
+  why += path_util::wstring_to_string(winpty_error_msg(error_ptr));
+  Napi::Error::New(env, why).ThrowAsJavaScriptException();
   winpty_error_free(error_ptr);
 }
 
-static NAN_METHOD(PtyGetExitCode) {
-  Nan::HandleScope scope;
+static Napi::Value PtyGetExitCode(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 1 ||
-      !info[0]->IsNumber()) {
-    Nan::ThrowError("Usage: pty.getExitCode(pid)");
-    return;
+      !info[0].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.getExitCode(pid)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  DWORD pid = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
   HANDLE handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
   if (handle == NULL) {
-    info.GetReturnValue().Set(Nan::New<v8::Number>(-1));
-    return;
+    return Napi::Number::New(env, -1);
   }
 
   DWORD exitCode = 0;
@@ -97,95 +98,89 @@ static NAN_METHOD(PtyGetExitCode) {
   }
 
   CloseHandle(handle);
-  info.GetReturnValue().Set(Nan::New<v8::Number>(exitCode));
+  return Napi::Number::New(env, exitCode);
 }
 
-static NAN_METHOD(PtyGetProcessList) {
-  Nan::HandleScope scope;
+static Napi::Value PtyGetProcessList(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 1 ||
-      !info[0]->IsNumber()) {
-    Nan::ThrowError("Usage: pty.getProcessList(pid)");
-    return;
+      !info[0].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.getProcessList(pid)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  DWORD pid = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
   winpty_t *pc = get_pipe_handle(pid);
   if (pc == nullptr) {
-    info.GetReturnValue().Set(Nan::New<v8::Array>(0));
-    return;
+    return Napi::Number::New(env, 0);
   }
   int processList[64];
   const int processCount = 64;
   int actualCount = winpty_get_console_process_list(pc, processList, processCount, nullptr);
   if (actualCount <= 0) {
-    info.GetReturnValue().Set(Nan::New<v8::Array>(0));
-    return;
+    return Napi::Number::New(env, 0);
   }
-  uint32_t actualCountSize = static_cast<uint32_t>(actualCount);
-  v8::Local<v8::Array> result = Nan::New<v8::Array>(actualCountSize);
-  for (uint32_t i = 0; i < actualCountSize; i++) {
-    Nan::Set(result, i, Nan::New<v8::Number>(processList[i]));
+  Napi::Array result = Napi::Array::New(env, actualCount);
+  for (int i = 0; i < actualCount; i++) {
+    result.Set(i, Napi::Number::New(env, processList[i]));
   }
-  info.GetReturnValue().Set(result);
+  return result;
 }
 
-static NAN_METHOD(PtyStartProcess) {
-  Nan::HandleScope scope;
+static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 7 ||
-      !info[0]->IsString() ||
-      !info[1]->IsString() ||
-      !info[2]->IsArray() ||
-      !info[3]->IsString() ||
-      !info[4]->IsNumber() ||
-      !info[5]->IsNumber() ||
-      !info[6]->IsBoolean()) {
-    Nan::ThrowError("Usage: pty.startProcess(file, cmdline, env, cwd, cols, rows, debug)");
-    return;
+      !info[0].IsString() ||
+      !info[1].IsString() ||
+      !info[2].IsArray() ||
+      !info[3].IsString() ||
+      !info[4].IsNumber() ||
+      !info[5].IsNumber() ||
+      !info[6].IsBoolean()) {
+    Napi::Error::New(env, "Usage: pty.startProcess(file, cmdline, env, cwd, cols, rows, debug)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  const wchar_t *filename = path_util::to_wstring(Nan::Utf8String(info[0]));
-  const wchar_t *cmdline = path_util::to_wstring(Nan::Utf8String(info[1]));
-  const wchar_t *cwd = path_util::to_wstring(Nan::Utf8String(info[3]));
+  std::wstring filename(path_util::to_wstring(info[0].As<Napi::String>()));
+  std::wstring cmdline(path_util::to_wstring(info[1].As<Napi::String>()));
+  std::wstring cwd(path_util::to_wstring(info[3].As<Napi::String>()));
 
   // create environment block
-  std::wstring env;
-  const v8::Local<v8::Array> envValues = v8::Local<v8::Array>::Cast(info[2]);
+  std::wstring envStr;
+  const Napi::Array envValues = info[2].As<Napi::Array>();
   if (!envValues.IsEmpty()) {
-
-    std::wstringstream envBlock;
-
-    for(uint32_t i = 0; i < envValues->Length(); i++) {
-      std::wstring envValue(path_util::to_wstring(Nan::Utf8String(Nan::Get(envValues, i).ToLocalChecked())));
-      envBlock << envValue << L'\0';
+    std::wstring envBlock;
+    for(uint32_t i = 0; i < envValues.Length(); i++) {
+      envBlock += path_util::to_wstring(envValues.Get(i).As<Napi::String>());
+      envBlock += L'\0';
     }
-
-    env = envBlock.str();
+    envStr = std::move(envBlock);
   }
 
   // use environment 'Path' variable to determine location of
   // the relative path that we have recieved (e.g cmd.exe)
   std::wstring shellpath;
-  if (::PathIsRelativeW(filename)) {
+  if (::PathIsRelativeW(filename.c_str())) {
     shellpath = path_util::get_shell_path(filename);
   } else {
     shellpath = filename;
   }
 
   if (shellpath.empty() || !path_util::file_exists(shellpath)) {
-    std::wstringstream why;
-    why << "File not found: " << shellpath;
-    Nan::ThrowError(path_util::from_wstring(why.str().c_str()));
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    std::string why;
+    why += "File not found: ";
+    why += path_util::wstring_to_string(shellpath);
+    Napi::Error::New(env, why).ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  int cols = info[4]->Int32Value(Nan::GetCurrentContext()).FromJust();
-  int rows = info[5]->Int32Value(Nan::GetCurrentContext()).FromJust();
-  bool debug = Nan::To<bool>(info[6]).FromJust();
+  int cols = info[4].As<Napi::Number>().Int32Value();
+  int rows = info[5].As<Napi::Number>().Int32Value();
+  bool debug = info[6].As<Napi::Boolean>().Value();
 
   // Enable/disable debugging
   SetEnvironmentVariable(WINPTY_DBG_VARIABLE, debug ? "1" : NULL); // NULL = deletes variable
@@ -194,11 +189,8 @@ static NAN_METHOD(PtyStartProcess) {
   winpty_error_ptr_t error_ptr = nullptr;
   winpty_config_t* winpty_config = winpty_config_new(0, &error_ptr);
   if (winpty_config == nullptr) {
-    throw_winpty_error("Error creating WinPTY config", error_ptr);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    throw_winpty_error("Error creating WinPTY config", error_ptr, env);
+    return env.Undefined();
   }
   winpty_error_free(error_ptr);
 
@@ -209,23 +201,17 @@ static NAN_METHOD(PtyStartProcess) {
   winpty_t *pc = winpty_open(winpty_config, &error_ptr);
   winpty_config_free(winpty_config);
   if (pc == nullptr) {
-    throw_winpty_error("Error launching WinPTY agent", error_ptr);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    throw_winpty_error("Error launching WinPTY agent", error_ptr, env);
+    return env.Undefined();
   }
   winpty_error_free(error_ptr);
 
   // Create winpty spawn config
-  winpty_spawn_config_t* config = winpty_spawn_config_new(WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN, shellpath.c_str(), cmdline, cwd, env.c_str(), &error_ptr);
+  winpty_spawn_config_t* config = winpty_spawn_config_new(WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN, shellpath.c_str(), cmdline.c_str(), cwd.c_str(), envStr.c_str(), &error_ptr);
   if (config == nullptr) {
-    throw_winpty_error("Error creating WinPTY spawn config", error_ptr);
+    throw_winpty_error("Error creating WinPTY spawn config", error_ptr, env);
     winpty_free(pc);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    return env.Undefined();
   }
   winpty_error_free(error_ptr);
 
@@ -234,121 +220,108 @@ static NAN_METHOD(PtyStartProcess) {
   BOOL spawnSuccess = winpty_spawn(pc, config, &handle, nullptr, nullptr, &error_ptr);
   winpty_spawn_config_free(config);
   if (!spawnSuccess) {
-    throw_winpty_error("Unable to start terminal process", error_ptr);
+    throw_winpty_error("Unable to start terminal process", error_ptr, env);
     if (handle) {
       CloseHandle(handle);
     }
     winpty_free(pc);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    return env.Undefined();
   }
   winpty_error_free(error_ptr);
 
   LPCWSTR coninPipeName = winpty_conin_name(pc);
   std::string coninPipeNameStr(path_util::from_wstring(coninPipeName));
   if (coninPipeNameStr.empty()) {
-    Nan::ThrowError("Failed to initialize winpty conin");
+    Napi::Error::New(env, "Failed to initialize winpty conin").ThrowAsJavaScriptException();
     CloseHandle(handle);
     winpty_free(pc);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    return env.Undefined();
   }
 
   LPCWSTR conoutPipeName = winpty_conout_name(pc);
   std::string conoutPipeNameStr(path_util::from_wstring(conoutPipeName));
   if (conoutPipeNameStr.empty()) {
-    Nan::ThrowError("Failed to initialize winpty conout");
+    Napi::Error::New(env, "Failed to initialize winpty conout").ThrowAsJavaScriptException();
     CloseHandle(handle);
     winpty_free(pc);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    return env.Undefined();
   }
 
   DWORD innerPid = GetProcessId(handle);
   if (createdHandles[innerPid]) {
     std::stringstream why;
     why << "There is already a process with innerPid " << innerPid;
-    Nan::ThrowError(why.str().c_str());
+    Napi::Error::New(env, why.str()).ThrowAsJavaScriptException();
     CloseHandle(handle);
     winpty_free(pc);
-    delete filename;
-    delete cmdline;
-    delete cwd;
-    return;
+    return env.Undefined();
   }
   createdHandles[innerPid] = handle;
 
   // Save pty struct for later use
   ptyHandles.push_back(pc);
 
-  v8::Local<v8::Object> marshal = Nan::New<v8::Object>();
   DWORD pid = GetProcessId(winpty_agent_process(pc));
-  Nan::Set(marshal, Nan::New<v8::String>("innerPid").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(innerPid)));
-  Nan::Set(marshal, Nan::New<v8::String>("pid").ToLocalChecked(), Nan::New<v8::Number>(static_cast<double>(pid)));
-  Nan::Set(marshal, Nan::New<v8::String>("pty").ToLocalChecked(), Nan::New<v8::Number>(InterlockedIncrement(&ptyCounter)));
-  Nan::Set(marshal, Nan::New<v8::String>("fd").ToLocalChecked(), Nan::New<v8::Number>(-1));
-  Nan::Set(marshal, Nan::New<v8::String>("conin").ToLocalChecked(), Nan::New<v8::String>(coninPipeNameStr).ToLocalChecked());
-  Nan::Set(marshal, Nan::New<v8::String>("conout").ToLocalChecked(), Nan::New<v8::String>(conoutPipeNameStr).ToLocalChecked());
-  info.GetReturnValue().Set(marshal);
+  Napi::Object marshal = Napi::Object::New(env);
+  marshal.Set(Napi::String::New(env, "innerPid"), Napi::Number::New(env, (int)innerPid));
+  marshal.Set(Napi::String::New(env, "pid"), Napi::Number::New(env, (int)pid));
+  marshal.Set(Napi::String::New(env, "pty"), Napi::Number::New(env, InterlockedIncrement(&ptyCounter)));
+  marshal.Set(Napi::String::New(env, "fd"), Napi::Number::New(env, -1));
+  marshal.Set(Napi::String::New(env, "conin"), Napi::String::New(env, coninPipeNameStr));
+  marshal.Set(Napi::String::New(env, "conout"), Napi::String::New(env, conoutPipeNameStr));
 
-  delete filename;
-  delete cmdline;
-  delete cwd;
+  return marshal;
 }
 
-static NAN_METHOD(PtyResize) {
-  Nan::HandleScope scope;
+static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 3 ||
-      !info[0]->IsNumber() ||
-      !info[1]->IsNumber() ||
-      !info[2]->IsNumber()) {
-    Nan::ThrowError("Usage: pty.resize(pid, cols, rows)");
-    return;
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.resize(pid, cols, rows)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  DWORD pid = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
-  int cols = info[1]->Int32Value(Nan::GetCurrentContext()).FromJust();
-  int rows = info[2]->Int32Value(Nan::GetCurrentContext()).FromJust();
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  int cols = info[1].As<Napi::Number>().Int32Value();
+  int rows = info[2].As<Napi::Number>().Int32Value();
 
   winpty_t *pc = get_pipe_handle(pid);
 
   if (pc == nullptr) {
-    Nan::ThrowError("The pty doesn't appear to exist");
-    return;
+    Napi::Error::New(env, "The pty doesn't appear to exist").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
   BOOL success = winpty_set_size(pc, cols, rows, nullptr);
   if (!success) {
-    Nan::ThrowError("The pty could not be resized");
-    return;
+    Napi::Error::New(env, "The pty could not be resized").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  return info.GetReturnValue().SetUndefined();
+  return env.Undefined();
 }
 
-static NAN_METHOD(PtyKill) {
-  Nan::HandleScope scope;
+static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
 
   if (info.Length() != 2 ||
-      !info[0]->IsNumber() ||
-      !info[1]->IsNumber()) {
-    Nan::ThrowError("Usage: pty.kill(pid, innerPid)");
-    return;
+      !info[0].IsNumber() ||
+      !info[1].IsNumber()) {
+    Napi::Error::New(env, "Usage: pty.kill(pid, innerPid)").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
-  DWORD pid = info[0]->Uint32Value(Nan::GetCurrentContext()).FromJust();
-  DWORD innerPid = info[1]->Uint32Value(Nan::GetCurrentContext()).FromJust();
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  DWORD innerPid = info[1].As<Napi::Number>().Uint32Value();
 
   winpty_t *pc = get_pipe_handle(pid);
   if (pc == nullptr) {
-    Nan::ThrowError("Pty seems to have been killed already");
-    return;
+    Napi::Error::New(env, "Pty seems to have been killed already").ThrowAsJavaScriptException();
+    return env.Undefined();
   }
 
   assert(remove_pipe_handle(pid));
@@ -357,20 +330,21 @@ static NAN_METHOD(PtyKill) {
   createdHandles.erase(innerPid);
   CloseHandle(innerPidHandle);
 
-  return info.GetReturnValue().SetUndefined();
+  return env.Undefined();
 }
 
 /**
 * Init
 */
 
-extern "C" void init(v8::Local<v8::Object> target) {
-  Nan::HandleScope scope;
-  Nan::SetMethod(target, "startProcess", PtyStartProcess);
-  Nan::SetMethod(target, "resize", PtyResize);
-  Nan::SetMethod(target, "kill", PtyKill);
-  Nan::SetMethod(target, "getExitCode", PtyGetExitCode);
-  Nan::SetMethod(target, "getProcessList", PtyGetProcessList);
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+  exports.Set(Napi::String::New(env, "startProcess"), Napi::Function::New(env, PtyStartProcess));
+  exports.Set(Napi::String::New(env, "resize"), Napi::Function::New(env, PtyResize));
+  exports.Set(Napi::String::New(env, "kill"), Napi::Function::New(env, PtyKill));
+  exports.Set(Napi::String::New(env, "getExitCode"), Napi::Function::New(env, PtyGetExitCode));
+  exports.Set(Napi::String::New(env, "getProcessList"), Napi::Function::New(env, PtyGetProcessList));
+  return exports;
 };
 
-NODE_MODULE(pty, init);
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/src/win/winpty.cc
+++ b/src/win/winpty.cc
@@ -322,7 +322,6 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
 */
 
 Napi::Object init(Napi::Env env, Napi::Object exports) {
-  Napi::HandleScope scope(env);
   exports.Set("startProcess", Napi::Function::New(env, PtyStartProcess));
   exports.Set("resize", Napi::Function::New(env, PtyResize));
   exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/src/win/winpty.cc
+++ b/src/win/winpty.cc
@@ -66,7 +66,7 @@ static bool remove_pipe_handle(DWORD pid) {
   return false;
 }
 
-void error_with_winpty_msg(const char *generalMsg, winpty_error_ptr_t error_ptr, Napi::Env env) {
+Napi::Error error_with_winpty_msg(const char *generalMsg, winpty_error_ptr_t error_ptr, Napi::Env env) {
   std::string why;
   why += generalMsg;
   why += ": ";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,11 +1318,6 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nan@^2.17.0:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
-  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
-
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -1342,6 +1337,11 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-addon-api@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.0.tgz#71f609369379c08e251c558527a107107b5e0fdb"
+  integrity sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==
 
 node-gyp@^9.4.0:
   version "9.4.0"


### PR DESCRIPTION
- [x] Port current code to NAPI, but ignore `onexit` support. Thanks to DavidRusso.
- [x] Implement `onexit`, fix the "5th pty bug" in #432 .
- [x] Port `__APPLE__` section in `pty_waitpid`.
- [x] Port windows part.
- [x] Test on [CI in my temp repo](https://github.com/kkocdko/utils4linux/actions).

Need no more to say, mainly about compatibility.

- **NodeJS version** (#557): Before this, only the version that vscode used. After this, from 16.x to future (21.x currently).
- **V8 version**: Electron combines latest V8 with LTS NodeJS.
- **Pointer compression**: Electron and some user (me) want [pointer compression](https://github.com/nodejs/build/issues/3204), use NAN needs recompile.
- **Bun** (#632): NAPI [was supported in Bun](https://bun.sh/docs/api/node-api) runtime, but NAN was not. However the NAPI in Bun seems still unstable.

### About "5th pty bug" in #432

The `Napi::AsyncWorker` spawn a libuv worker thread which is limited by [UV_THREADPOOL_SIZE](https://nodejs.org/api/cli.html#uv_threadpool_sizesize) (default = 4). It's more suitable for IO operations that need this limitation.

### I want to taste now!

This PR only modify the native code, so just download from [CI](https://github.com/kkocdko/utils4linux/actions/runs/7120087088) (see "Artifacts") then replace the origin files in `./build/Release/`. Looking for macOS user because I have no macOS device.