### PR TITLE
chore: remove deprecated api `process.binding`

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -5,6 +5,7 @@
  */
 import * as net from 'net';
 import * as path from 'path';
+import * as tty from 'tty';
 import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
 import { IProcessEnv, IPtyForkOptions, IPtyOpenOptions } from './interfaces';
 import { ArgvOrCommandLine } from './types';
@@ -113,7 +114,7 @@ export class UnixTerminal extends Terminal {
     // fork
     const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
 
-    this._socket = new net.Socket({ fd: term.fd });
+    this._socket = new tty.ReadStream(term.fd);
     if (encoding !== null) {
       this._socket.setEncoding(encoding);
     }
@@ -203,13 +204,13 @@ export class UnixTerminal extends Terminal {
     // open
     const term: IUnixOpenProcess = pty.open(cols, rows);
 
-    self._master = new net.Socket({ fd: term.master });
+    self._master = new tty.ReadStream(term.master);
     if (encoding !== null) {
       self._master.setEncoding(encoding);
     }
     self._master.resume();
 
-    self._slave = new net.Socket({ fd: term.slave });
+    self._slave = new tty.ReadStream(term.slave);
     if (encoding !== null) {
       self._slave.setEncoding(encoding);
     }

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -113,7 +113,7 @@ export class UnixTerminal extends Terminal {
     // fork
     const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
 
-    this._socket = new PipeSocket(term.fd);
+    this._socket = new net.Socket({ fd: term.fd });
     if (encoding !== null) {
       this._socket.setEncoding(encoding);
     }
@@ -203,13 +203,13 @@ export class UnixTerminal extends Terminal {
     // open
     const term: IUnixOpenProcess = pty.open(cols, rows);
 
-    self._master = new PipeSocket(<number>term.master);
+    self._master = new net.Socket({ fd: term.master });
     if (encoding !== null) {
       self._master.setEncoding(encoding);
     }
     self._master.resume();
 
-    self._slave = new PipeSocket(term.slave);
+    self._slave = new net.Socket({ fd: term.slave });
     if (encoding !== null) {
       self._slave.setEncoding(encoding);
     }
@@ -302,20 +302,5 @@ export class UnixTerminal extends Terminal {
     delete env['TERMCAP'];
     delete env['COLUMNS'];
     delete env['LINES'];
-  }
-}
-
-/**
- * Wraps net.Socket to force the handle type "PIPE" by temporarily overwriting
- * tty_wrap.guessHandleType.
- * See: https://github.com/chjj/pty.js/issues/103
- */
-class PipeSocket extends net.Socket {
-  constructor(fd: number) {
-    const pipeWrap = (<any>process).binding('pipe_wrap'); // tslint:disable-line
-    // @types/node has fd as string? https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18275
-    const handle = new pipeWrap.Pipe(pipeWrap.constants.SOCKET);
-    handle.open(fd);
-    super(<any>{ handle });
   }
 }


### PR DESCRIPTION
This code from pty.js (chjj) was originally designed to work with ancient versions of node.js `0.12` and io.js, but the api is **[DEPRECATED](https://github.com/nodejs/node/issues/22064)** for many years, the `/* require("node:tty") */ tty.ReadStream` consturctor received a pipe fd is just worked (both r/w).

Related to #632 .

See https://github.com/nodejs/node/issues/37780 also.

<!--

After this PR and [NAPI Fixes in Bun](https://github.com/oven-sh/bun/issues/7685) and [My port to NAPI](https://github.com/microsoft/node-pty/pull/644), we can bring node-pty to bun now!

Fixed #632

-->