### PR TITLE
fix: assertion on node environment shutdown

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -189,9 +189,22 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
       exit_event->signal_code = WTERMSIG(stat_loc);
     }
     auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
-    assert(status == napi_ok);
+    switch (status) {
+      case napi_closing:
+        break;
 
-    tsfn.Release();
+      case napi_queue_full:
+        Napi::Error::Fatal("SetupExitCallback", "Queue was full");
+
+      case napi_ok:
+        if (tsfn.Release() != napi_ok) {
+          Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.Release() failed");
+        }
+        break;
+
+      default:
+        Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.BlockingCall() failed");
+    }
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/node-pty/issues/671

When main thread is exiting signaled by `napi_closing` we cannot touch tsfn, patch adjusts the checks for this scenario which happens on application exit.