### PR TITLE
Fix beta versioning

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -41,7 +41,7 @@ function getNextBetaVersion() {
   const nextStableVersion = `${stableVersion[0]}.${parseInt(stableVersion[1]) + 1}.0`;
   const publishedVersions = getPublishedVersions(nextStableVersion, tag);
   if (publishedVersions.length === 0) {
-    return `${nextStableVersion}-${tag}1`;
+    return `${nextStableVersion}-${tag}.1`;
   }
   const latestPublishedVersion = publishedVersions.sort((a, b) => {
     const aVersion = parseInt(a.substr(a.search(/[0-9]+$/)));
@@ -49,14 +49,14 @@ function getNextBetaVersion() {
     return aVersion > bVersion ? -1 : 1;
   })[0];
   const latestTagVersion = parseInt(latestPublishedVersion.substr(latestPublishedVersion.search(/[0-9]+$/)), 10);
-  return `${nextStableVersion}-${tag}${latestTagVersion + 1}`;
+  return `${nextStableVersion}-${tag}.${latestTagVersion + 1}`;
 }
 
 function getPublishedVersions(version, tag) {
   const versionsProcess = cp.spawnSync('npm', ['view', packageJson.name, 'versions', '--json']);
   const versionsJson = JSON.parse(versionsProcess.stdout);
   if (tag) {
-    return versionsJson.filter(v => !v.search(new RegExp(`${version}-${tag}[0-9]+`)));
+    return versionsJson.filter(v => !v.search(new RegExp(`${version}-${tag}\.[0-9]+`)));
   }
   return versionsJson;
 }


### PR DESCRIPTION
Beta versions currently have suffixes like `-beta1`, `-beta2`, `-beta3` etc. That works fine until we reach `.beta10`. Unfortunately, the `10` in there is not treated numerically, so according to npm’s semver `-beta2` is “higher” than `-beta10`. Numbers only seem to be treated numerically when preceded by a `.`.

In this example, I want `-1` all the time, but it fails when going from 9 to 10:

```
> require("semver").compare("1.0.0-beta8", "1.0.0-beta9")
-1

> require("semver").compare("1.0.0-beta9", "1.0.0-beta10")
1 // 🚨 !!!

> require("semver").compare("1.0.0-beta10", "1.0.0-beta11")
-1
```

But with a dot it works:

```
> require("semver").compare("1.0.0-beta.8", "1.0.0-beta.9")
-1

> require("semver").compare("1.0.0-beta.9", "1.0.0-beta.10")
-1

> require("semver").compare("1.0.0-beta.10", "1.0.0-beta.11")
-1
```

Unfortunately, `1.1.0-beta.13` is considered _lower_ than `1.1.0-beta12`, so I recommend waiting with merging this until you have released the next stable version. 

```
> require("semver").compare("1.1.0-beta.13", "1.1.0-beta12")
-1
```