### PR TITLE
Adding support for supplementary groups for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const ptyProcess = pty.spawn(shell, [], {
   env: process.env
 });
 
-ptyProcess.onData((data) => {
+ptyProcess.on('data', (data) => {
   process.stdout.write(data);
 });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -115,6 +115,7 @@ interface IBasePtyForkOptions {
 export interface IPtyForkOptions extends IBasePtyForkOptions {
   uid?: number;
   gid?: number;
+  suppGids?: number[];
 }
 
 export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -19,7 +19,7 @@ interface IWinptyNative {
 }
 
 interface IUnixNative {
-  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
+  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void, suppGids: number[]): IUnixProcess;
   open(cols: number, rows: number): IUnixOpenProcess;
   process(fd: number, pty?: string): string;
   resize(fd: number, cols: number, rows: number): void;

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -111,8 +111,10 @@ export class UnixTerminal extends Terminal {
       this.emit('exit', code, signal);
     };
 
+    const suppGids = opt.suppGids || [];
+
     // fork
-    const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
+    const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit, suppGids);
 
     this._socket = new tty.ReadStream(term.fd);
     if (encoding !== null) {


### PR DESCRIPTION
Closes #684

## Changes

## Functional
- Adding a new optional `suppGids` parameter for `node-pty.spawn` that allows to provide supplementary group IDs for Linux. The parameter will take effect only if `gid` and `uid` are provided. 

## Technical

- Fixed a minor typo in the `README` example.