### PR TITLE
Include termios.h on freebsd

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -41,6 +41,7 @@
 #include <util.h>
 #elif defined(__FreeBSD__)
 #include <libutil.h>
+#include <termios.h>
 #endif
 
 /* Some platforms name VWERASE and VDISCARD differently */


### PR DESCRIPTION
termios.h is a header built in to freebsd, but it must be imported here to work. build ran successfully after i added this. relates to https://github.com/coder/code-server/issues/6842