### PR TITLE
Ship third_party folder with module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 *.test.js
 *.test.ts
-third_party/


### PR DESCRIPTION
This needs to be there to copy over the right binary on postinstall

Part of microsoft/vscode#224488