### PR TITLE
Add support for terminal handoff

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -21,7 +21,11 @@
               'AdditionalOptions': [
                 '/guard:cf'
               ]
-            }
+            },
+            'VCMIDLTool': {
+              'OutputDirectory': '<(INTERMEDIATE_DIR)',
+              'HeaderFileName': '<(RULE_INPUT_ROOT).h',
+            },
           },
       }],
     ],
@@ -33,7 +37,13 @@
           'target_name': 'conpty',
           'sources' : [
             'src/win/conpty.cc',
-            'src/win/path_util.cc'
+            'src/win/path_util.cc',
+            'src/win/ITerminalHandoff.idl'
+          ],
+          'include_dirs' : [
+            'deps/wil/include',
+            # To allow including "ITerminalHandoff.h"
+            '<(INTERMEDIATE_DIR)',
           ],
           'libraries': [
             'shlwapi.lib'

--- a/src/win/ITerminalHandoff.idl
+++ b/src/win/ITerminalHandoff.idl
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import "unknwn.idl";
+
+typedef struct _TERMINAL_STARTUP_INFO
+{
+    // In STARTUPINFO
+    BSTR pszTitle;
+
+    // Also wanted
+    BSTR pszIconPath;
+    LONG iconIndex;
+
+    // The rest of STARTUPINFO
+    DWORD dwX;
+    DWORD dwY;
+    DWORD dwXSize;
+    DWORD dwYSize;
+    DWORD dwXCountChars;
+    DWORD dwYCountChars;
+    DWORD dwFillAttribute;
+    DWORD dwFlags;
+    WORD wShowWindow;
+} TERMINAL_STARTUP_INFO;
+
+// LOAD BEARING!
+//
+// There is only ever one OpenConsoleProxy.dll loaded by COM for _ALL_ terminal
+// instances, across Dev, Preview, Stable, whatever. So we have to keep all old
+// versions of interfaces in the file here, even if the old version is no longer
+// in use.
+
+// This was the original prototype. The reasons for changes to it are explained below.
+[
+    object,
+    uuid(59D55CCE-FC8A-48B4-ACE8-0A9286C6557F)
+] interface ITerminalHandoff : IUnknown
+{
+    // DEPRECATED!
+    HRESULT EstablishPtyHandoff([in, system_handle(sh_pipe)] HANDLE in,
+                                [in, system_handle(sh_pipe)] HANDLE out,
+                                [in, system_handle(sh_pipe)] HANDLE signal,
+                                [in, system_handle(sh_file)] HANDLE ref,
+                                [in, system_handle(sh_process)] HANDLE server,
+                                [in, system_handle(sh_process)] HANDLE client);
+};
+
+// We didn't consider the need for TERMINAL_STARTUP_INFO, because Windows Terminal never had support for launching
+// .lnk files in the first place. They aren't executables after all, but rather a shell thing.
+// Its need quickly became apparent right after releasing ITerminalHandoff, which is why it was very short-lived.
+[
+    object,
+    uuid(AA6B364F-4A50-4176-9002-0AE755E7B5EF)
+] interface ITerminalHandoff2 : IUnknown
+{
+    HRESULT EstablishPtyHandoff([in, system_handle(sh_pipe)] HANDLE in,
+                                [in, system_handle(sh_pipe)] HANDLE out,
+                                [in, system_handle(sh_pipe)] HANDLE signal,
+                                [in, system_handle(sh_file)] HANDLE ref,
+                                [in, system_handle(sh_process)] HANDLE server,
+                                [in, system_handle(sh_process)] HANDLE client,
+                                [in] TERMINAL_STARTUP_INFO startupInfo);
+};
+
+// Quite a while later, we realized that passing the in/out handles as [in] instead of [out] has always been flawed.
+// It prevents the terminal from making choices over the pipe buffer size and whether to use overlapped IO or not.
+// The other handles remain [in] parameters because they have always been created internally by ConPTY.
+// Additionally, passing TERMINAL_STARTUP_INFO by-value was unusual under COM as structs are usually given by-ref.
+[
+    object,
+    uuid(6F23DA90-15C5-4203-9DB0-64E73F1B1B00)
+] interface ITerminalHandoff3 : IUnknown
+{
+    HRESULT EstablishPtyHandoff([out, system_handle(sh_pipe)] HANDLE* in,
+                                [out, system_handle(sh_pipe)] HANDLE* out,
+                                [in, system_handle(sh_pipe)] HANDLE signal,
+                                [in, system_handle(sh_file)] HANDLE reference,
+                                [in, system_handle(sh_process)] HANDLE server,
+                                [in, system_handle(sh_process)] HANDLE client,
+                                [in] const TERMINAL_STARTUP_INFO* startupInfo);
+};


### PR DESCRIPTION
TODO:
- [x] Out-of-process COM register
- [ ] Setup conpty `ConptyPackPseudoConsole` https://github.com/microsoft/terminal/blob/main/src/cascadia/TerminalConnection/ConptyConnection.cpp#L284
- [ ] Node.js callback

Issues?
Looks like COM requires a proxy dll to do marshaling. In Windows Terminal this dll is `OpenConsoleProxy.dll`. We have to ship the proxy dll with this project.

ref: microsoft/terminal#7414, microsoft/terminal#9462