### PR TITLE
Catch possible exceptions in ~Agent

### DIFF
--- a/deps/winpty/src/agent/Agent.cc
+++ b/deps/winpty/src/agent/Agent.cc
@@ -223,10 +223,18 @@ Agent::Agent(LPCWSTR controlPipeName,
 
 Agent::~Agent()
 {
-    trace("Agent::~Agent entered");
-    agentShutdown();
-    if (m_childProcess != NULL) {
-        CloseHandle(m_childProcess);
+    trace("Agent::~Aent entered");
+    try {
+        agentShutdown();
+        if (m_childProcess != NULL) {
+            CloseHandle(m_childProcess);
+        }
+    } catch (const std::exception &e) {
+        // Log the exception or handle it as needed
+        trace("Exception in Agent::~Agent: %s", e.what());
+    } catch (...) {
+        // Catch any other types of exceptions
+        trace("Unknown exception in Agent::~Agent");
     }
 }
 


### PR DESCRIPTION
Fixes warning:

deps\winpty\src\agent\Agent.cc(231): warning C4722: 'Agent::~Agent': destructor never returns, potential memory leak

---

Tested by building and running `node ./examples/fork/index.js`