### PR TITLE
Add support for conpty terminal handoff

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
  * Copyright (c) 2018, Microsoft Corporation (MIT License).
  */
 
-import { ITerminal, IPtyOpenOptions, IPtyForkOptions, IWindowsPtyForkOptions } from './interfaces';
+import { ITerminal, IPtyOpenOptions, IPtyForkOptions, IWindowsPtyForkOptions, IConptyHandoffHandles } from './interfaces';
 import { ArgvOrCommandLine } from './types';
 
 let terminalCtor: any;
@@ -42,6 +42,14 @@ export function createTerminal(file?: string, args?: ArgvOrCommandLine, opt?: IP
 
 export function open(options: IPtyOpenOptions): ITerminal {
   return terminalCtor.open(options);
+}
+
+export function handoff(handoff: IConptyHandoffHandles, opt?: IWindowsPtyForkOptions): ITerminal {
+  opt = opt || {};
+  opt.useConpty = true;
+  opt.useConptyDll = true;
+  opt.conptyHandoff = handoff;
+  return new terminalCtor(undefined, undefined, opt);
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -121,10 +121,20 @@ export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {
   useConpty?: boolean;
   useConptyDll?: boolean;
   conptyInheritCursor?: boolean;
+  conptyHandoff?: IConptyHandoffHandles;
 }
 
 export interface IPtyOpenOptions {
   cols?: number;
   rows?: number;
   encoding?: string | null;
+}
+
+export interface IConptyHandoffHandles {
+  input?: number;
+  output?: number;
+  signal?: number;
+  ref?: number;
+  server?: number; // ConPty process
+  client?: number; // Shell process
 }

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -8,6 +8,7 @@ interface IConptyNative {
   resize(ptyId: number, cols: number, rows: number, useConptyDll: boolean): void;
   clear(ptyId: number, useConptyDll: boolean): void;
   kill(ptyId: number, useConptyDll: boolean): void;
+  handoff(input: number, output: number, signal: number, ref: number, server: number, client: number, onExitCallback: (exitCode: number) => void): IWinptyProcess;
 }
 
 interface IWinptyNative {
@@ -28,15 +29,15 @@ interface IUnixNative {
 interface IConptyProcess {
   pty: number;
   fd: number;
-  conin: string;
-  conout: string;
+  conin: string | number;
+  conout: string | number;
 }
 
 interface IWinptyProcess {
   pty: number;
   fd: number;
-  conin: string;
-  conout: string;
+  conin: string | number;
+  conout: string | number;
   pid: number;
   innerPid: number;
 }

--- a/src/shared/conout.ts
+++ b/src/shared/conout.ts
@@ -4,6 +4,7 @@
 
 export interface IWorkerData {
   conoutPipeName: string;
+  conoutFD?: number;
 }
 
 export const enum ConoutWorkerMessage {

--- a/src/windowsConoutConnection.ts
+++ b/src/windowsConoutConnection.ts
@@ -37,9 +37,10 @@ export class ConoutConnection implements IDisposable {
   public get onReady(): IEvent<void> { return this._onReady.event; }
 
   constructor(
-    private _conoutPipeName: string
+    private _conoutPipeName: string,
+    conoutFD: number | undefined,
   ) {
-    const workerData: IWorkerData = { conoutPipeName: _conoutPipeName };
+    const workerData: IWorkerData = { conoutPipeName: _conoutPipeName, conoutFD };
     const scriptPath = __dirname.replace('node_modules.asar', 'node_modules.asar.unpacked');
     this._worker = new Worker(join(scriptPath, 'worker/conoutSocketWorker.js'), { workerData });
     this._worker.on('message', (message: ConoutWorkerMessage) => {

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -17,6 +17,8 @@ declare module 'node-pty' {
    */
   export function spawn(file: string, args: string[] | string, options: IPtyForkOptions | IWindowsPtyForkOptions): IPty;
 
+  export function handoff(handoff: IConptyHandoffHandles, opt?: IWindowsPtyForkOptions): IPty;
+
   export interface IBasePtyForkOptions {
 
     /**
@@ -108,6 +110,15 @@ declare module 'node-pty' {
      * @see https://docs.microsoft.com/en-us/windows/console/createpseudoconsole
      */
     conptyInheritCursor?: boolean;
+  }
+
+  export interface IConptyHandoffHandles {
+    input?: number;
+    output?: number;
+    signal?: number;
+    ref?: number;
+    server?: number; // ConPty process
+    client?: number; // Shell process
   }
 
   /**


### PR DESCRIPTION
This PR add a `pty.handoff({ input, output, signal, ref, server, client });` function.
To allow passing handoff handles and get a ITerminal interface.

This function need to use with https://github.com/ysc3839/node-terminal-handoff
The usage is:
```js
const pty = require('node-pty');
const handoff = require('terminal-handoff');

handoff.register(/*clsid=*/'{E12CFF52-A866-4C77-9A90-F570A7AA2C6B}', /*callback=*/function (input, output, signal, ref, server, client) {
  const handoffHandles = { input, output, signal, ref, server, client };
  const pty = pty.handoff(handoffHandles);
}, /*once=*/false);
```

Old PR is #716.