### PR TITLE
chore: add new publish pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ resources:
       ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
     sdl:
       sourceAnalysisPool: 1es-oss-windows-2022-x64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ extends:
         - job: macOS
           pool:
             name: Azure Pipelines
-            vmImage: 'macOS-latest'
+            vmImage: 'macOS-14'
             os: macOS
           steps:
           - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,23 +24,16 @@ extends:
           pool:
             name: 1es-oss-ubuntu-22.04-x64
             os: Linux
-          strategy:
-            matrix:
-              node_20_x:
-                node_version: 20.x
           steps:
           - task: NodeTool@0
             inputs:
-              versionSpec: $(node_version)
+              versionSpec: 20.x
             displayName: 'Install Node.js'
-          - script: |
-              npm i
+          - script: npm ci
             displayName: 'Install dependencies and build'
-          - script: |
-              npm test
+          - script: npm test
             displayName: 'Test'
-          - script: |
-              npm run lint
+          - script: npm run lint
             displayName: 'Lint'
 
         - job: macOS
@@ -48,73 +41,32 @@ extends:
             name: Azure Pipelines
             vmImage: 'macOS-latest'
             os: macOS
-          strategy:
-            matrix:
-              node_20_x:
-                node_version: 20.x
           steps:
           - task: NodeTool@0
             inputs:
-              versionSpec: $(node_version)
+              versionSpec: 20.x
             displayName: 'Install Node.js'
-          - script: |
-              python3 -m pip install setuptools
+          - script: python3 -m pip install setuptools
             displayName: Install setuptools (macOS)
-          - script: |
-              npm i
+          - script: npm ci
             displayName: 'Install dependencies and build'
-          - script: |
-              npm test
+          - script: npm test
             displayName: 'Test'
-          - script: |
-              npm run lint
+          - script: npm run lint
             displayName: 'Lint'
 
         - job: Windows
           pool:
             name: 1es-oss-windows-2022-x64
             os: Windows
-          strategy:
-            matrix:
-              node_20_x:
-                node_version: 20.x
           steps:
           - task: NodeTool@0
             inputs:
-              versionSpec: $(node_version)
+              versionSpec: 20.x
             displayName: 'Install Node.js'
-          - script: |
-              npm i
+          - script: npm ci
             displayName: 'Install dependencies and build'
-          - script: |
-              npm test
+          - script: npm test
             displayName: 'Test'
-          - script: |
-              npm run lint
+          - script: npm run lint
             displayName: 'Lint'
-
-      - stage: Release
-        dependsOn: Build
-        jobs:
-          - job: Release
-            condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-            # Output artifact to produce SBOM and to run SDL checks
-            templateContext:
-              outputs:
-              - output: pipelineArtifact
-                targetPath: $(Build.SourcesDirectory)
-                artifactName: drop
-            pool:
-              name: 1es-oss-ubuntu-22.04-x64
-              os: Linux
-            steps:
-            - task: NodeTool@0
-              inputs:
-                versionSpec: '20.x'
-              displayName: 'Install Node.js'
-            - script: |
-                npm i
-              displayName: 'Install dependencies and build'
-            - script: |
-                NPM_AUTH_TOKEN="$(NPM_AUTH_TOKEN)" node ./scripts/publish.js
-              displayName: 'Publish to npm'

--- a/publish.yml
+++ b/publish.yml
@@ -37,6 +37,8 @@ extends:
         buildSteps:
           - script: npm ci
             displayName: 'Install dependencies and build'
+          # The following script leaves the version unchanged for
+          # stable releases, but increments the version for beta releases.
           - script: node scripts/increment-version.js
             displayName: 'Increment version'
 

--- a/publish.yml
+++ b/publish.yml
@@ -28,6 +28,10 @@ parameters:
       - beta
       - stable
 
+variables:
+  - name: releaseQuality
+    value: ${{ parameters.releaseQuality }}
+
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
   parameters:
@@ -51,7 +55,7 @@ extends:
             displayName: 'Lint'
 
         publishPackage: ${{ parameters.publishPackage }}
-        ${{ if eq(parameters.releaseQuality, 'stable') }}:
+        ${{ if eq(variables['releaseQuality'], 'stable') }}:
           tag: latest
         ${{ else }}:
           tag: beta

--- a/publish.yml
+++ b/publish.yml
@@ -1,0 +1,44 @@
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+pr: none
+
+resources:
+  repositories:
+    - repository: templates
+      type: github
+      name: microsoft/vscode-engineering
+      ref: main
+      endpoint: Monaco
+
+parameters:
+  - name: publishPackage
+    displayName: 🚀 Publish node-pty
+    type: boolean
+    default: false
+
+extends:
+  template: azure-pipelines/npm-package/pipeline.yml@templates
+  parameters:
+    npmPackages:
+      - name: node-pty
+
+        buildSteps:
+          - script: npm ci
+            displayName: 'Install dependencies and build'
+          - script: node scripts/increment-version.js
+            displayName: 'Increment version'
+
+        testSteps:
+          - script: npm ci
+            displayName: 'Install dependencies and build'
+          - script: npm test
+            displayName: 'Test'
+          - script: npm run lint
+            displayName: 'Lint'
+
+        publishPackage: ${{ parameters.publishPackage }}

--- a/publish.yml
+++ b/publish.yml
@@ -20,6 +20,13 @@ parameters:
     displayName: 🚀 Publish node-pty
     type: boolean
     default: false
+  - name: releaseQuality
+    displayName: Quality
+    type: string
+    default: beta
+    values:
+      - beta
+      - stable
 
 extends:
   template: azure-pipelines/npm-package/pipeline.yml@templates
@@ -42,3 +49,7 @@ extends:
             displayName: 'Lint'
 
         publishPackage: ${{ parameters.publishPackage }}
+        ${{ if eq(parameters.releaseQuality, 'stable') }}:
+          tag: latest
+        ${{ else }}:
+          tag: beta

--- a/scripts/increment-version.js
+++ b/scripts/increment-version.js
@@ -7,29 +7,18 @@ const fs = require('fs');
 const path = require('path');
 const packageJson = require('../package.json');
 
-// Setup auth
-fs.writeFileSync(`${process.env['HOME']}/.npmrc`, `//registry.npmjs.org/:_authToken=${process.env['NPM_AUTH_TOKEN']}`);
-
 // Determine if this is a stable or beta release
 const publishedVersions = getPublishedVersions();
-const isStableRelease = publishedVersions.indexOf(packageJson.version) === -1;
+const isStableRelease = !publishedVersions.includes(packageJson.version);
 
 // Get the next version
-let nextVersion = isStableRelease ? packageJson.version : getNextBetaVersion();
-console.log(`Publishing version: ${nextVersion}`);
+const nextVersion = isStableRelease ? packageJson.version : getNextBetaVersion();
+console.log(`Setting version to ${nextVersion}`);
 
 // Set the version in package.json
 const packageJsonFile = path.resolve(__dirname, '..', 'package.json');
 packageJson.version = nextVersion;
 fs.writeFileSync(packageJsonFile, JSON.stringify(packageJson, null, 2));
-
-// Publish
-const args = ['publish'];
-if (!isStableRelease) {
-  args.push('--tag', 'beta');
-}
-const result = cp.spawn('npm', args, { stdio: 'inherit' });
-result.on('exit', code => process.exit(code));
 
 function getNextBetaVersion() {
   if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.exec(packageJson.version)) {


### PR DESCRIPTION
Also fixes up the existing pipeline to become a CI-only pipeline.
One issue with the new pipeline is that it uses the package.json version. I'm not sure how to let it auto-generate a new beta version.