### PR TITLE
Allow pty.kill to be awaited

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -253,7 +253,7 @@ export class UnixTerminal extends Terminal {
     this._socket.destroy();
   }
 
-  public kill(signal?: string): void {
+  public async kill(signal?: string): Promise<void> {
     try {
       process.kill(this.pid, signal || 'SIGHUP');
     } catch (e) { /* swallow */ }

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -162,7 +162,7 @@ export class WindowsPtyAgent {
     this._outSocket.readable = false;
     // Tell the agent to kill the pty, this releases handles to the process
     if (this._useConpty) {
-      let consoleProcessList = await this._getConsoleProcessList();
+      const consoleProcessList = await this._getConsoleProcessList();
       consoleProcessList.forEach((pid: number) => {
         try {
           process.kill(pid);

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -157,21 +157,20 @@ export class WindowsPtyAgent {
     }
   }
 
-  public kill(): void {
+  public async kill(): Promise<void> {
     this._inSocket.readable = false;
     this._outSocket.readable = false;
     // Tell the agent to kill the pty, this releases handles to the process
     if (this._useConpty) {
-      this._getConsoleProcessList().then(consoleProcessList => {
-        consoleProcessList.forEach((pid: number) => {
-          try {
-            process.kill(pid);
-          } catch (e) {
-            // Ignore if process cannot be found (kill ESRCH error)
-          }
-        });
-        (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
+      let consoleProcessList = await this._getConsoleProcessList();
+      consoleProcessList.forEach((pid: number) => {
+        try {
+          process.kill(pid);
+        } catch (e) {
+          // Ignore if process cannot be found (kill ESRCH error)
+        }
       });
+      (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
     } else {
       // Because pty.kill closes the handle, it will kill most processes by itself.
       // Process IDs can be reused as soon as all handles to them are

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -175,7 +175,7 @@ export class WindowsTerminal extends Terminal {
         this._close();
         this._agent.kill().then(res);
       });
-    })
+    });
   }
 
   private _deferNoArgs<A>(deferredFn: () => void): void {

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -166,14 +166,16 @@ export class WindowsTerminal extends Terminal {
     });
   }
 
-  public kill(signal?: string): void {
-    this._deferNoArgs(() => {
-      if (signal) {
-        throw new Error('Signals not supported on windows.');
-      }
-      this._close();
-      this._agent.kill();
-    });
+  public kill(signal?: string): Promise<void> {
+    return new Promise((res) => {
+      this._deferNoArgs(() => {
+        if (signal) {
+          throw new Error('Signals not supported on windows.');
+        }
+        this._close();
+        this._agent.kill().then(res);
+      });
+    })
   }
 
   private _deferNoArgs<A>(deferredFn: () => void): void {

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -167,13 +167,13 @@ export class WindowsTerminal extends Terminal {
   }
 
   public kill(signal?: string): Promise<void> {
-    return new Promise((res) => {
+    return new Promise((res, rej) => {
       this._deferNoArgs(() => {
         if (signal) {
-          throw new Error('Signals not supported on windows.');
+          rej(new Error('Signals not supported on windows.'));
         }
         this._close();
-        this._agent.kill().then(res);
+        this._agent.kill().then(res, rej);
       });
     });
   }

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -171,6 +171,7 @@ export class WindowsTerminal extends Terminal {
       this._deferNoArgs(() => {
         if (signal) {
           rej(new Error('Signals not supported on windows.'));
+          return;
         }
         this._close();
         this._agent.kill().then(res, rej);

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -181,7 +181,7 @@ declare module 'node-pty' {
      * Windows.
      * @throws Will throw when signal is used on Windows.
      */
-    kill(signal?: string): void;
+    kill(signal?: string): Promise<void>;
 
     /**
      * Pauses the pty for customizable flow control.

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -179,7 +179,7 @@ declare module 'node-pty' {
      * Kills the pty.
      * @param signal The signal to use, defaults to SIGHUP. This parameter is not supported on
      * Windows.
-     * @throws Will throw when signal is used on Windows.
+     * @throws Will reject when signal is used on Windows.
      */
     kill(signal?: string): Promise<void>;
 


### PR DESCRIPTION
Currently there isn't a good way to know when a pseudoterminal is fully killed, since there is some asynchronous logic on windows. This means that there isn't a good way to clean up any active pseudoterminals in electron before shutdown, as described in #733, because if the app is quit before the terminals are fully killed the process will hang. This PR allows `pty.kill` to be awaited, so the app can be shut down only after any pseudoterminals are fully killed, making a clean solution like this possible:

```js
const { app } = require("electron");
const { spawn } = require("node-pty");

app.whenReady().then(async () => {
    let pty = spawn("cmd.exe");

    // process exits normally
    await pty.kill();
    app.quit();
});
```

Fixes https://github.com/microsoft/node-pty/issues/733