### PR TITLE
fix: publish pipeline broken APIScan task

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -59,3 +59,7 @@ extends:
           tag: latest
         ${{ else }}:
           tag: beta
+
+        apiScanExcludes: 'package/third_party/conpty/1.20.240626001/win10-arm64/*.*'
+        apiScanSoftwareName: 'vscode-node-pty'
+        apiScanSoftwareVersion: '1'

--- a/publish.yml
+++ b/publish.yml
@@ -54,7 +54,6 @@ extends:
           - script: npm run lint
             displayName: 'Lint'
 
-        apiScanUseZ7: true
         publishPackage: ${{ parameters.publishPackage }}
         ${{ if eq(variables['releaseQuality'], 'stable') }}:
           tag: latest

--- a/publish.yml
+++ b/publish.yml
@@ -54,6 +54,7 @@ extends:
           - script: npm run lint
             displayName: 'Lint'
 
+        apiScanUseZ7: true
         publishPackage: ${{ parameters.publishPackage }}
         ${{ if eq(variables['releaseQuality'], 'stable') }}:
           tag: latest

--- a/scripts/increment-version.js
+++ b/scripts/increment-version.js
@@ -43,7 +43,10 @@ function getNextBetaVersion() {
 
 function getPublishedVersions(version, tag) {
   const versionsProcess = cp.spawnSync('npm', ['view', packageJson.name, 'versions', '--json']);
-  const versionsJson = JSON.parse(versionsProcess.stdout);
+  const buffer = Buffer.from(versionsProcess.stdout).toString('utf-8');
+  console.log('buffer is', buffer);
+  console.log('typeof buffer is', typeof buffer);
+  const versionsJson = JSON.parse(buffer);
   if (tag) {
     return versionsJson.filter(v => !v.search(new RegExp(`${version}-${tag}[0-9]+`)));
   }

--- a/scripts/increment-version.js
+++ b/scripts/increment-version.js
@@ -42,11 +42,11 @@ function getNextBetaVersion() {
 }
 
 function getPublishedVersions(version, tag) {
-  const versionsProcess = cp.spawnSync('npm', ['view', packageJson.name, 'versions', '--json']);
-  const buffer = Buffer.from(versionsProcess.stdout).toString('utf-8');
-  console.log('buffer is', buffer);
-  console.log('typeof buffer is', typeof buffer);
-  const versionsJson = JSON.parse(buffer);
+  const isWin32 = process.platform === 'win32';
+  const versionsProcess = isWin32 ?
+    cp.spawnSync('npm.cmd', ['view', packageJson.name, 'versions', '--json'], { shell: true }) :
+    cp.spawnSync('npm', ['view', packageJson.name, 'versions', '--json']);
+  const versionsJson = JSON.parse(versionsProcess.stdout);
   if (tag) {
     return versionsJson.filter(v => !v.search(new RegExp(`${version}-${tag}[0-9]+`)));
   }


### PR DESCRIPTION
The new publish pipeline was breaking on the APIScan stage.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=315607&view=results