### PR TITLE
chore: add BinSkim flags to winpty

### DIFF
--- a/deps/winpty/src/winpty.gyp
+++ b/deps/winpty/src/winpty.gyp
@@ -24,6 +24,28 @@
             # run the script (re)generating the version header.
             '<!(cmd /c "cd shared && UpdateGenVersion.bat <(WINPTY_COMMIT_HASH)")',
         ],
+        'conditions': [
+            ['OS=="win"', {
+                'msvs_configuration_attributes': {
+                    'SpectreMitigation': 'Spectre'
+                },
+                'msvs_settings': {
+                    'VCCLCompilerTool': {
+                        'AdditionalOptions': [
+                            '/guard:cf',
+                            '/w34244',
+                            '/w34267',
+                            '/ZH:SHA_256'
+                        ]
+                    },
+                    'VCLinkerTool': {
+                        'AdditionalOptions': [
+                            '/guard:cf'
+                        ]
+                    }
+                },
+            }],
+        ],
     },
     'targets' : [
         {

--- a/deps/winpty/src/winpty.gyp
+++ b/deps/winpty/src/winpty.gyp
@@ -23,29 +23,7 @@
             # Add the 'src/gen' directory to the include path and force gyp to
             # run the script (re)generating the version header.
             '<!(cmd /c "cd shared && UpdateGenVersion.bat <(WINPTY_COMMIT_HASH)")',
-        ],
-        'conditions': [
-            ['OS=="win"', {
-                'msvs_configuration_attributes': {
-                    'SpectreMitigation': 'Spectre'
-                },
-                'msvs_settings': {
-                    'VCCLCompilerTool': {
-                        'AdditionalOptions': [
-                            '/guard:cf',
-                            '/w34244',
-                            '/w34267',
-                            '/ZH:SHA_256'
-                        ]
-                    },
-                    'VCLinkerTool': {
-                        'AdditionalOptions': [
-                            '/guard:cf'
-                        ]
-                    }
-                },
-            }],
-        ],
+        ]
     },
     'targets' : [
         {
@@ -62,12 +40,26 @@
                 '-lshell32',
                 '-luser32',
             ],
+            'msvs_configuration_attributes': {
+                'SpectreMitigation': 'Spectre'
+            },
             'msvs_settings': {
                 # Specify this setting here to override a setting from somewhere
                 # else, such as node's common.gypi.
                 'VCCLCompilerTool': {
                     'ExceptionHandling': '1', # /EHsc
+                    'AdditionalOptions': [
+                        '/guard:cf',
+                        '/w34244',
+                        '/w34267',
+                        '/ZH:SHA_256'
+                    ]
                 },
+                'VCLinkerTool': {
+                    'AdditionalOptions': [
+                        '/guard:cf'
+                    ]
+                }
             },
             'sources' : [
                 'agent/Agent.h',
@@ -150,12 +142,26 @@
                 '-ladvapi32',
                 '-luser32',
             ],
+            'msvs_configuration_attributes': {
+                'SpectreMitigation': 'Spectre'
+            },
             'msvs_settings': {
                 # Specify this setting here to override a setting from somewhere
                 # else, such as node's common.gypi.
                 'VCCLCompilerTool': {
                     'ExceptionHandling': '1', # /EHsc
+                    'AdditionalOptions': [
+                        '/guard:cf',
+                        '/w34244',
+                        '/w34267',
+                        '/ZH:SHA_256'
+                    ]
                 },
+                'VCLinkerTool': {
+                    'AdditionalOptions': [
+                        '/guard:cf'
+                    ]
+                }
             },
             'sources' : [
                 'include/winpty.h',


### PR DESCRIPTION
This PR adds BinSkim flags to node-pty's winpty executables.

- The ZH:SHA_256 flag only affects debug info.
- The guard:cf flag enables the control flow guard. I've added Deepak to this PR to confirm that we can add it in this context, but I believe we're fine.
- The w34244 and w34267 flags turn on some compiler warnings but do not break the build. These compiler warnings _all_ have to do with implicit conversions between various integer types. If we really wanted to resolve the warning without changing the code, we can add `static_cast` everywhere to turn the implicit conversions into explicit ones.

This PR also adds Spectre mitigation to the executables.