### PR TITLE
Use overlapped over mode for contpy named pipe

### DIFF
--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -143,7 +143,7 @@ bool createDataServerPipe(bool write,
 
   name = L"\\\\.\\pipe\\" + pipeName + L"-" + kind;
 
-  const DWORD winOpenMode =  PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE/*  | FILE_FLAG_OVERLAPPED */;
+  const DWORD winOpenMode =  PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE | FILE_FLAG_OVERLAPPED;
 
   SECURITY_ATTRIBUTES sa = {};
   sa.nLength = sizeof(sa);


### PR DESCRIPTION
Fixes #771

Was commented out since the initial implementation, not sure if we need to do anything else?