### PR TITLE
fix: gate conpty-exclusive call behind conpty check

### DIFF
--- a/src/win/conpty.cc
+++ b/src/win/conpty.cc
@@ -428,7 +428,7 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
 
   HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
   bool fLoadedDll = hLibrary != nullptr;
-  if (fLoadedDll)
+  if (useConptyDll && fLoadedDll)
   {
     PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
       (HMODULE)hLibrary, "ConptyReleasePseudoConsole");


### PR DESCRIPTION
fLoadedDll only checks if a DLL loaded successfully, so there is a risk that the code would load kernel32.dll and then try calling into the ConPTY API.

Thanks to APIScan for catching this issue. 