### PR TITLE
Revert "chore: remove deprecated api `process.binding` (#653)"

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -5,7 +5,6 @@
  */
 import * as net from 'net';
 import * as path from 'path';
-import * as tty from 'tty';
 import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
 import { IProcessEnv, IPtyForkOptions, IPtyOpenOptions } from './interfaces';
 import { ArgvOrCommandLine } from './types';
@@ -114,7 +113,7 @@ export class UnixTerminal extends Terminal {
     // fork
     const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
 
-    this._socket = new tty.ReadStream(term.fd);
+    this._socket = new PipeSocket(term.fd);
     if (encoding !== null) {
       this._socket.setEncoding(encoding);
     }
@@ -204,13 +203,13 @@ export class UnixTerminal extends Terminal {
     // open
     const term: IUnixOpenProcess = pty.open(cols, rows);
 
-    self._master = new tty.ReadStream(term.master);
+    self._master = new PipeSocket(<number>term.master);
     if (encoding !== null) {
       self._master.setEncoding(encoding);
     }
     self._master.resume();
 
-    self._slave = new tty.ReadStream(term.slave);
+    self._slave = new PipeSocket(term.slave);
     if (encoding !== null) {
       self._slave.setEncoding(encoding);
     }
@@ -303,5 +302,20 @@ export class UnixTerminal extends Terminal {
     delete env['TERMCAP'];
     delete env['COLUMNS'];
     delete env['LINES'];
+  }
+}
+
+/**
+ * Wraps net.Socket to force the handle type "PIPE" by temporarily overwriting
+ * tty_wrap.guessHandleType.
+ * See: https://github.com/chjj/pty.js/issues/103
+ */
+class PipeSocket extends net.Socket {
+  constructor(fd: number) {
+    const pipeWrap = (<any>process).binding('pipe_wrap'); // tslint:disable-line
+    // @types/node has fd as string? https://github.com/DefinitelyTyped/DefinitelyTyped/pull/18275
+    const handle = new pipeWrap.Pipe(pipeWrap.constants.SOCKET);
+    handle.open(fd);
+    super(<any>{ handle });
   }
 }


### PR DESCRIPTION
This reverts commit 391347926a45bb0b9e2c9a9f837adc56592b3c4b.

Since the terminal `write` method has no way to communicate backpressure to the caller and doesn't handle it internally, quickly successive calls to `write` or calls with long enough data can cause a loop where the node process gets stuck repeatedly trying to write data that the terminal process did not read quickly enough.

https://github.com/microsoft/node-pty/blob/24b53bbf573ed7ab35f8897aa8b690dbd9064fc9/src/interfaces.ts#L25

Fixes https://github.com/microsoft/node-pty/issues/797