### PR TITLE
feat: add prebuilds to published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 *.test.js
 *.test.ts
+_manifest/

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": "tsc -b ./src/tsconfig.json",
     "watch": "tsc -b -w ./src/tsconfig.json",
     "lint": "eslint -c .eslintrc.js --ext .ts src/",
+    "install": "node scripts/prebuild.js || node-gyp rebuild",
     "postinstall": "node scripts/post-install.js",
     "compileCommands": "node scripts/gen-compile-commands.js",
     "test": "cross-env NODE_ENV=test mocha -R spec --exit lib/*.test.js",

--- a/pipelines/prebuilds.yml
+++ b/pipelines/prebuilds.yml
@@ -20,7 +20,7 @@ extends:
     stages:
       - stage: Build
         jobs:
-          - job: windows-x64
+          - job: win32_x64
             pool:
               name: 1es-windows-2022-x64
               os: windows
@@ -33,7 +33,7 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: x64
-          - job: windows-arm64
+          - job: win32_arm64
             pool:
               name: 1es-windows-2022-x64
               os: windows
@@ -46,7 +46,7 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: arm64
-          - job: macOS-x64
+          - job: macOS_x64
             pool:
               name: Azure Pipelines
               vmImage: macOS-latest
@@ -60,7 +60,7 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: x64
-          - job: macOS-arm64
+          - job: macOS_arm64
             pool:
               name: Azure Pipelines
               vmImage: macOS-latest
@@ -74,7 +74,7 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: arm64
-          - job: linux-x64
+          - job: linux_x64
             pool:
               name: 1es-ubuntu-22.04-x64
               os: linux
@@ -87,7 +87,7 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: x64
-          - job: linux-arm64
+          - job: linux_arm64
             pool:
               name: 1es-mariner-2.0-arm64
               os: linux

--- a/pipelines/prebuilds.yml
+++ b/pipelines/prebuilds.yml
@@ -89,7 +89,7 @@ extends:
                 arch: x64
           - job: linux_arm64
             pool:
-              name: 1es-mariner-2.0-arm64
+              name: 1es-ubuntu-22.04-x64
               os: linux
             templateContext:
               outputs:

--- a/pipelines/prebuilds.yml
+++ b/pipelines/prebuilds.yml
@@ -100,3 +100,44 @@ extends:
             - template: pipelines/build.yml@self
               parameters:
                 arch: arm64
+
+      - stage: Archive
+        jobs:
+          - job: archive
+            pool:
+              name: 1es-ubuntu-22.04-x64
+              os: linux
+            templateContext:
+              inputs:
+                - input: pipelineArtifact
+                  artifactName: win32-x64
+                  targetPath: $(Build.ArtifactStagingDirectory)/win32-x64
+                - input: pipelineArtifact
+                  artifactName: win32-arm64
+                  targetPath: $(Build.ArtifactStagingDirectory)/win32-arm64
+                - input: pipelineArtifact
+                  artifactName: macOS-x64
+                  targetPath: $(Build.ArtifactStagingDirectory)/macOS-x64
+                - input: pipelineArtifact
+                  artifactName: macOS-arm64
+                  targetPath: $(Build.ArtifactStagingDirectory)/macOS-arm64
+                - input: pipelineArtifact
+                  artifactName: linux-x64
+                  targetPath: $(Build.ArtifactStagingDirectory)/linux-x64
+                - input: pipelineArtifact
+                  artifactName: linux-arm64
+                  targetPath: $(Build.ArtifactStagingDirectory)/linux-arm64
+              outputs:
+                - output: pipelineArtifact
+                  targetPath: $(Build.ArtifactStagingDirectory)/prebuilds
+                  artifactName: 'prebuilds'
+            steps:
+              - script: |
+                  mkdir -p $(Build.ArtifactStagingDirectory)/prebuilds
+                  cp -r $(Build.ArtifactStagingDirectory)/win32-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/win32-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/macOS-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/macOS-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/linux-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/linux-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                displayName: 'Create prebuilds archive'

--- a/pipelines/prebuilds.yml
+++ b/pipelines/prebuilds.yml
@@ -55,7 +55,7 @@ extends:
               outputs:
                 - output: pipelineArtifact
                   targetPath: $(Build.SourcesDirectory)/build/Release
-                  artifactName: 'macOS-x64'
+                  artifactName: 'darwin-x64'
             steps:
             - template: pipelines/build.yml@self
               parameters:
@@ -69,7 +69,7 @@ extends:
               outputs:
                 - output: pipelineArtifact
                   targetPath: $(Build.SourcesDirectory)/build/Release
-                  artifactName: 'macOS-arm64'
+                  artifactName: 'darwin-arm64'
             steps:
             - template: pipelines/build.yml@self
               parameters:
@@ -116,11 +116,11 @@ extends:
                   artifactName: win32-arm64
                   targetPath: $(Build.ArtifactStagingDirectory)/win32-arm64
                 - input: pipelineArtifact
-                  artifactName: macOS-x64
-                  targetPath: $(Build.ArtifactStagingDirectory)/macOS-x64
+                  artifactName: darwin-x64
+                  targetPath: $(Build.ArtifactStagingDirectory)/darwin-x64
                 - input: pipelineArtifact
-                  artifactName: macOS-arm64
-                  targetPath: $(Build.ArtifactStagingDirectory)/macOS-arm64
+                  artifactName: darwin-arm64
+                  targetPath: $(Build.ArtifactStagingDirectory)/darwin-arm64
                 - input: pipelineArtifact
                   artifactName: linux-x64
                   targetPath: $(Build.ArtifactStagingDirectory)/linux-x64
@@ -136,8 +136,8 @@ extends:
                   mkdir -p $(Build.ArtifactStagingDirectory)/prebuilds
                   cp -r $(Build.ArtifactStagingDirectory)/win32-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
                   cp -r $(Build.ArtifactStagingDirectory)/win32-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
-                  cp -r $(Build.ArtifactStagingDirectory)/macOS-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
-                  cp -r $(Build.ArtifactStagingDirectory)/macOS-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/darwin-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
+                  cp -r $(Build.ArtifactStagingDirectory)/darwin-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
                   cp -r $(Build.ArtifactStagingDirectory)/linux-x64 $(Build.ArtifactStagingDirectory)/prebuilds/
                   cp -r $(Build.ArtifactStagingDirectory)/linux-arm64 $(Build.ArtifactStagingDirectory)/prebuilds/
                 displayName: 'Create prebuilds archive'

--- a/pipelines/prebuilds.yml
+++ b/pipelines/prebuilds.yml
@@ -31,7 +31,8 @@ extends:
                   artifactName: 'win32-x64'
             steps:
             - template: pipelines/build.yml@self
-              arch: x64
+              parameters:
+                arch: x64
           - job: windows-arm64
             pool:
               name: 1es-windows-2022-x64
@@ -43,7 +44,8 @@ extends:
                   artifactName: 'win32-arm64'
             steps:
             - template: pipelines/build.yml@self
-              arch: arm64
+              parameters:
+                arch: arm64
           - job: macOS-x64
             pool:
               name: Azure Pipelines
@@ -56,7 +58,8 @@ extends:
                   artifactName: 'macOS-x64'
             steps:
             - template: pipelines/build.yml@self
-              arch: x64
+              parameters:
+                arch: x64
           - job: macOS-arm64
             pool:
               name: Azure Pipelines
@@ -69,7 +72,8 @@ extends:
                   artifactName: 'macOS-arm64'
             steps:
             - template: pipelines/build.yml@self
-              arch: arm64
+              parameters:
+                arch: arm64
           - job: linux-x64
             pool:
               name: 1es-ubuntu-22.04-x64
@@ -81,7 +85,8 @@ extends:
                   artifactName: 'linux-x64'
             steps:
             - template: pipelines/build.yml@self
-              arch: x64
+              parameters:
+                arch: x64
           - job: linux-arm64
             pool:
               name: 1es-mariner-2.0-arm64
@@ -93,4 +98,5 @@ extends:
                   artifactName: 'linux-arm64'
             steps:
             - template: pipelines/build.yml@self
-              arch: arm64
+              parameters:
+                arch: arm64

--- a/publish.yml
+++ b/publish.yml
@@ -39,6 +39,14 @@ extends:
       - name: node-pty
 
         buildSteps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download prebuilds'
+            inputs:
+              pipeline: '647'
+              runVersion: 'latestFromBranch'
+              runBranch: 'main'
+              artifact: 'prebuilds'
+              targetPath: 'prebuilds'
           - script: npm ci
             displayName: 'Install dependencies and build'
           # The following script leaves the version unchanged for
@@ -47,6 +55,14 @@ extends:
             displayName: 'Increment version'
 
         testSteps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download prebuilds'
+            inputs:
+              pipeline: '647'
+              runVersion: 'latestFromBranch'
+              runBranch: 'main'
+              artifact: 'prebuilds'
+              targetPath: 'prebuilds'
           - script: npm ci
             displayName: 'Install dependencies and build'
           - script: npm test

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -11,6 +11,16 @@ const path = require('path');
  *     node scripts/prebuild.js
  */
 
+// Skip copying prebuilds when npm_config_build_from_source is set
+const buildFromSource = process.env.npm_config_build_from_source;
+if (buildFromSource) {
+  const val = buildFromSource.toLowerCase();
+  if (val !== 'false' && val !== '0' && val !== '') {
+    console.log('\x1b[33m> Skipping prebuild copy because npm_config_build_from_source is set\x1b[0m');
+    process.exit(1);
+  }
+}
+
 const PREBUILD_DIR = path.join(__dirname, '..', 'prebuilds', `${process.platform}-${process.arch}`);
 const RELEASE_DIR = path.join(__dirname, '../build/Release');
 

--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -12,13 +12,9 @@ const path = require('path');
  */
 
 // Skip copying prebuilds when npm_config_build_from_source is set
-const buildFromSource = process.env.npm_config_build_from_source;
-if (buildFromSource) {
-  const val = buildFromSource.toLowerCase();
-  if (val !== 'false' && val !== '0' && val !== '') {
-    console.log('\x1b[33m> Skipping prebuild copy because npm_config_build_from_source is set\x1b[0m');
-    process.exit(1);
-  }
+if (process.env.npm_config_build_from_source === 'true') {
+  console.log('\x1b[33m> Skipping prebuild copy because npm_config_build_from_source is set\x1b[0m');
+  process.exit(1);
 }
 
 const PREBUILD_DIR = path.join(__dirname, '..', 'prebuilds', `${process.platform}-${process.arch}`);


### PR DESCRIPTION
Adds onto #803 and #794.

This PR fixes up the new native prebuilds ADO pipeline to produce a combined artifact, and it allows the ADO publishing pipeline to consume that artifact.