### PR TITLE
chore: update SDL flags

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,13 +12,14 @@
             'VCCLCompilerTool': {
               'AdditionalOptions': [
                 '/guard:cf',
-                '/w34244',
-                '/we4267',
+                '/sdl',
+                '/W3',
                 '/ZH:SHA_256'
               ]
             },
             'VCLinkerTool': {
               'AdditionalOptions': [
+                '/DYNAMICBASE',
                 '/guard:cf'
               ]
             }


### PR DESCRIPTION
This PR updates the binding.gyp flags in accordance with the latest SDL assessment requirements.

One of the requirements is to use /W3. All warnings generated from /W3 currently come from the winpty dependency. We at most need to file an upstream issue if winpty is still in development; I don't think it is reasonable for us to fix these warnings ourselves.

The other requirement is to add flags such as /sdl and /DYNAMICBASE, which are in this PR.