### PR TITLE
chore: remove excess quotes

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -86,8 +86,8 @@ extends:
           publishRequiresApproval: false
 
         apiScanExcludes: |
-          'package/third_party/conpty/**/win10-arm64/*.*'
-          'package/prebuilds/win32-arm64/conpty/*.*'
-          'package/prebuilds/win32-arm64/*.*'
+          package/third_party/conpty/**/win10-arm64/*.*
+          package/prebuilds/win32-arm64/conpty/*.*
+          package/prebuilds/win32-arm64/*.*
         apiScanSoftwareName: 'vscode-node-pty'
         apiScanSoftwareVersion: '1'


### PR DESCRIPTION
This PR fixes the apiScanExcludes parameter by removing the excess quotes. Because the parameter is already a multi-line string, the quotes become part of the string and cause the globs to not match any file.