### PR TITLE
chore: use UseNode

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,9 @@ extends:
             name: 1es-oss-ubuntu-22.04-x64
             os: Linux
           steps:
-          - task: NodeTool@0
+          - task: UseNode@1
             inputs:
-              versionSpec: 22.x
+              version: 22.x
             displayName: 'Install Node.js'
           - script: npm ci
             displayName: 'Install dependencies and build'
@@ -49,9 +49,9 @@ extends:
             vmImage: 'macOS-14'
             os: macOS
           steps:
-          - task: NodeTool@0
+          - task: UseNode@1
             inputs:
-              versionSpec: 22.x
+              version: 22.x
             displayName: 'Install Node.js'
           - script: npm ci
             displayName: 'Install dependencies and build'
@@ -65,9 +65,9 @@ extends:
             name: 1es-oss-windows-2022-x64
             os: Windows
           steps:
-          - task: NodeTool@0
+          - task: UseNode@1
             inputs:
-              versionSpec: 22.x
+              version: 22.x
             displayName: 'Install Node.js'
           - script: npm ci
             displayName: 'Install dependencies and build'

--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -2,9 +2,9 @@ parameters:
   arch: 'x64'
 
 steps:
-- task: NodeTool@0
+- task: UseNode@1
   inputs:
-    versionSpec: '22.x'
+    version: '22.x'
   displayName: 'Install Node.js 22.x'
 
 - task: UsePythonVersion@0
@@ -17,4 +17,4 @@ steps:
   displayName: 'Install dependencies'
   env:
     ARCH: ${{ parameters.arch }}
-    npm_config_arch: ${{ parameters.arch }} 
+    npm_config_arch: ${{ parameters.arch }}


### PR DESCRIPTION
Bumps `NodeTool@0` to `UseNode@1` to try and resolve CI failures.