### PR TITLE
feat: support to build with mingw-w64 in windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,7 @@
             'src/win/path_util.cc'
           ],
           'libraries': [
-            'shlwapi.lib'
+            '-lshlwapi'
           ],
         },
         {
@@ -63,7 +63,7 @@
             'src/win/path_util.cc'
           ],
           'libraries': [
-            'shlwapi.lib'
+            '-lshlwapi'
           ],
         }
       ]


### PR DESCRIPTION
* Use standard -lshlwapi in binding.gyp so gyp/node-gyp can handle linking for both mingw-w64 and MSVC, enabling builds with mingw-w64.