### PR TITLE
fix: do not delete prebuilds for OS mismatch

### DIFF
--- a/scripts/prebuild.js
+++ b/scripts/prebuild.js
@@ -27,8 +27,7 @@ if (process.env.npm_config_build_from_source === 'true') {
 // Check whether the correct prebuilt files exist
 console.log('\x1b[32m> Checking prebuilds...\x1b[0m');
 if (!fs.existsSync(PREBUILD_DIR)) {
-  console.log(`\x1b[33m> Removing prebuilds and rebuilding because directory ${PREBUILD_DIR} does not exist\x1b[0m`);
-  fs.rmSync(PREBUILDS_ROOT, { recursive: true, force: true });
+  console.log(`\x1b[33m> Rebuilding because directory ${PREBUILD_DIR} does not exist\x1b[0m`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Beta 40 shipped without any prebuilds because it was built on Linux, which does not use them. This PR removes an unnecessary rmSync call so that the next beta release can ship with prebuilt binaries again for third parties.