### PR TITLE
chore: remove fortify-source flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -80,7 +80,7 @@
           'libraries': [
             '-lutil'
           ],
-          'cflags': ['-Wall', '-O2', '-D_FORTIFY_SOURCE=2'],
+          'cflags': ['-Wall', '-O2'],
           'ldflags': [],
           'conditions': [
             # http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html


### PR DESCRIPTION
This flag is not compatible with the sysroots used to build VS Code on Linux.