### PR TITLE
Exclude unnecessary files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-*.test.js
-*.test.ts
-_manifest/

--- a/deps/.editorconfig
+++ b/deps/.editorconfig
@@ -1,2 +1,0 @@
-# Have editor config ignore this directory
-root = true

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   },
   "files": [
     "binding.gyp",
-    "lib/",
-    "scripts/",
-    "src/",
-    "deps/",
+    "lib/**/*.js",
+    "!lib/**/*.test.js",
+    "scripts/post-install.js",
+    "scripts/prebuild.js",
+    "src/**/*.{cc,h}",
     "prebuilds/",
     "third_party/",
     "typings/"


### PR DESCRIPTION
Diff of `npm pack` output, before and after this PR:

```diff
diff --git a/before.txt b/after.txt
index e01b6be..0c8f79e 100644
--- a/before.txt
+++ b/after.txt
@@ -4,81 +4,29 @@ npm notice Tarball Contents
 npm notice 3.3kB LICENSE
 npm notice 8.0kB README.md
 npm notice 4.6kB binding.gyp
-npm notice 55B deps/.editorconfig
 npm notice 721B lib/conpty_console_list_agent.js
-npm notice 475B lib/conpty_console_list_agent.js.map
 npm notice 1.6kB lib/eventEmitter2.js
-npm notice 1.2kB lib/eventEmitter2.js.map
-npm notice 1.3kB lib/eventEmitter2.test.js
-npm notice 1.4kB lib/eventEmitter2.test.js.map
 npm notice 2.0kB lib/index.js
-npm notice 987B lib/index.js.map
 npm notice 233B lib/interfaces.js
-npm notice 124B lib/interfaces.js.map
 npm notice 348B lib/shared/conout.js
-npm notice 204B lib/shared/conout.js.map
 npm notice 7.5kB lib/terminal.js
-npm notice 5.8kB lib/terminal.js.map
-npm notice 6.3kB lib/terminal.test.js
-npm notice 4.2kB lib/terminal.test.js.map
-npm notice 807B lib/testUtils.test.js
-npm notice 622B lib/testUtils.test.js.map
 npm notice 228B lib/types.js
-npm notice 114B lib/types.js.map
 npm notice 13.4kB lib/unixTerminal.js
-npm notice 9.7kB lib/unixTerminal.js.map
-npm notice 20.9kB lib/unixTerminal.test.js
-npm notice 12.4kB lib/unixTerminal.test.js.map
 npm notice 1.5kB lib/utils.js
-npm notice 1.1kB lib/utils.js.map
 npm notice 6.1kB lib/windowsConoutConnection.js
-npm notice 1.7kB lib/windowsConoutConnection.js.map
 npm notice 9.9kB lib/windowsPtyAgent.js
-npm notice 7.3kB lib/windowsPtyAgent.js.map
-npm notice 4.1kB lib/windowsPtyAgent.test.js
-npm notice 3.0kB lib/windowsPtyAgent.test.js.map
 npm notice 7.8kB lib/windowsTerminal.js
-npm notice 5.0kB lib/windowsTerminal.js.map
-npm notice 10.5kB lib/windowsTerminal.test.js
-npm notice 8.7kB lib/windowsTerminal.test.js.map
 npm notice 848B lib/worker/conoutSocketWorker.js
-npm notice 635B lib/worker/conoutSocketWorker.js.map
-npm notice 1.6kB package.json
-npm notice 260B scripts/gen-compile-commands.js
-npm notice 2.2kB scripts/increment-version.js
-npm notice 225B scripts/linux/checksums.txt
-npm notice 5.6kB scripts/linux/install-sysroot.js
-npm notice 1.4kB scripts/linux/verify-glibc-requirements.sh
+npm notice 1.7kB package.json
 npm notice 2.4kB scripts/post-install.js
 npm notice 1.2kB scripts/prebuild.js
-npm notice 582B src/conpty_console_list_agent.ts
-npm notice 975B src/eventEmitter2.test.ts
-npm notice 1.1kB src/eventEmitter2.ts
-npm notice 2.2kB src/index.ts
-npm notice 3.3kB src/interfaces.ts
-npm notice 1.3kB src/native.d.ts
-npm notice 291B src/shared/conout.ts
-npm notice 4.4kB src/terminal.test.ts
-npm notice 6.7kB src/terminal.ts
-npm notice 567B src/testUtils.test.ts
-npm notice 323B src/tsconfig.json
-npm notice 306B src/types.ts
 npm notice 21.9kB src/unix/pty.cc
 npm notice 494B src/unix/spawn-helper.cc
-npm notice 14.5kB src/unixTerminal.test.ts
-npm notice 11.0kB src/unixTerminal.ts
-npm notice 997B src/utils.ts
 npm notice 1.4kB src/win/conpty_console_list.cc
 npm notice 19.6kB src/win/conpty.cc
 npm notice 1.7kB src/win/conpty.h
 npm notice 2.6kB src/win/path_util.cc
 npm notice 695B src/win/path_util.h
-npm notice 2.8kB src/windowsConoutConnection.ts
-npm notice 3.4kB src/windowsPtyAgent.test.ts
-npm notice 8.0kB src/windowsPtyAgent.ts
-npm notice 8.0kB src/windowsTerminal.test.ts
-npm notice 5.7kB src/windowsTerminal.ts
-npm notice 713B src/worker/conoutSocketWorker.ts
 npm notice 106.5kB third_party/conpty/1.23.251008001/win10-arm64/conpty.dll
 npm notice 1.2MB third_party/conpty/1.23.251008001/win10-arm64/OpenConsole.exe
 npm notice 109.6kB third_party/conpty/1.23.251008001/win10-x64/conpty.dll
@@ -89,8 +37,8 @@ npm notice name: node-pty
 npm notice version: 1.1.0
 npm notice filename: node-pty-1.1.0.tgz
 npm notice package size: 1.3 MB
-npm notice unpacked size: 2.9 MB
-npm notice shasum: 96a48faf68f136a0d22f3a2e2f5fd0eb077fdfc2
-npm notice integrity: sha512-/bCqqIKbS4Qtg[...]0Rk8WDSadLnbg==
-npm notice total files: 83
+npm notice unpacked size: 2.7 MB
+npm notice shasum: e8650b7b9ee81f75c654e6cdf36b6ed8c2e70e75
+npm notice integrity: sha512-BK+BLeknwpijP[...]pKtBbYD1edoBw==
+npm notice total files: 31
 npm notice
```

52 unnecessary files removed.