### PR TITLE
chore: add stack-protector-strong flag

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -9,24 +9,24 @@
           'SpectreMitigation': 'Spectre'
         },
         'msvs_settings': {
-            'VCCLCompilerTool': {
-              'AdditionalOptions': [
-                '/guard:cf',
-                '/sdl',
-                '/W3',
-                '/we4146',
-                '/we4244',
-                '/we4267',
-                '/ZH:SHA_256'
-              ]
-            },
-            'VCLinkerTool': {
-              'AdditionalOptions': [
-                '/DYNAMICBASE',
-                '/guard:cf'
-              ]
-            }
+          'VCCLCompilerTool': {
+            'AdditionalOptions': [
+              '/guard:cf',
+              '/sdl',
+              '/W3',
+              '/we4146',
+              '/we4244',
+              '/we4267',
+              '/ZH:SHA_256'
+            ]
           },
+          'VCLinkerTool': {
+            'AdditionalOptions': [
+              '/DYNAMICBASE',
+              '/guard:cf'
+            ]
+          }
+        },
       }, {
         'cflags': ['-O2', '-fstack-protector-strong'],
       }],


### PR DESCRIPTION
This PR adds the stack-protector-strong flag to the library, which adds stack canaries to the Linux builds in order to mitigate several BinSkim issues.

TODO:
- [x] Confirm that performance does not regress.
- [x] Confirm that all files that need the flag have the flag.