### PR TITLE
docs: add smart-terminal-mcp to real-world uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ ptyProcess.write('ls\r');
 - [OpenSumi](https://github.com/opensumi/core): A framework helps you quickly build Cloud or Desktop IDE products.
 - [Enjoy Git](https://github.com/huangcs427/enjoy-git-release): A modern Git client featuring an intuitive user interface, built with Electron, Vue 3, and TypeScript.
 - [Logos](https://github.com/zixiao-labs/logos): A Modern, Lightweight Code Editor, built with Electron, Vue 3, and TypeScript.
-- [smart-terminal-mcp](https://github.com/pungggi/smart-terminal-mcp): A Windows-native MCP server that gives AI agents real interactive terminal access via pseudo-terminals.
+- [smart-terminal-mcp](https://github.com/pungggi/smart-terminal-mcp): An MCP server that gives AI agents real interactive terminal access via pseudo-terminals.
 
 Do you use node-pty in your application as well? Please open a [Pull Request](https://github.com/Tyriar/node-pty/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
## Summary
- add `smart-terminal-mcp` to the README's Real-world Uses list

## Why
`smart-terminal-mcp` is an MCP server that gives AI agents real interactive terminal access via pseudo-terminals.
