### PR TITLE
fix: swallow resize() error when conpty has already exited

### DIFF
--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -130,7 +130,7 @@ export class WindowsPtyAgent {
 
   public resize(cols: number, rows: number): void {
     if (this._exitCode !== undefined) {
-      throw new Error('Cannot resize a pty that has already exited');
+      return;
     }
     this._ptyNative.resize(this._pty, cols, rows, this._useConptyDll);
   }


### PR DESCRIPTION
## Summary

- Silently ignore `resize()` calls after the PTY process has already exited instead of throwing `'Cannot resize a pty that has already exited'`
- Prevents crashes on Windows with Node.js v22 when a resize is triggered after process exit (e.g. during terminal cleanup)

Fixes #827

## Details

The native conpty `_exitCode` guard previously threw an error, which could crash the host process if the caller didn't wrap `resize()` in a try/catch. This is a race condition that's more likely to surface on Node.js v22 due to timing changes in its stream/event loop internals.

The fix mirrors the existing graceful handling already in place on Unix (`EBADF` swallow in `unixTerminal.ts`).

## Test plan

- [ ] Reproduce crash from #827 on Windows + Node.js v22, confirm it no longer throws after this change
- [ ] Verify normal resize still works when PTY is active