### PR TITLE
fix: swallow resize() errors after PTY exit on Windows and Unix

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -274,7 +274,13 @@ export class UnixTerminal extends Terminal {
     }
     const pixelWidth = pixelSize?.width ?? 0;
     const pixelHeight = pixelSize?.height ?? 0;
-    pty.resize(this._fd, cols, rows, pixelWidth, pixelHeight);
+    try {
+      pty.resize(this._fd, cols, rows, pixelWidth, pixelHeight);
+    } catch (e: any) {
+      // EBADF means the fd is already closed (PTY destroyed before resize fires); ignore it
+      if (e?.code === 'EBADF' || e?.message?.includes('EBADF')) { return; }
+      throw e;
+    }
     this._cols = cols;
     this._rows = rows;
   }

--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -130,7 +130,7 @@ export class WindowsPtyAgent {
 
   public resize(cols: number, rows: number): void {
     if (this._exitCode !== undefined) {
-      throw new Error('Cannot resize a pty that has already exited');
+      return;
     }
     this._ptyNative.resize(this._pty, cols, rows, this._useConptyDll);
   }


### PR DESCRIPTION
## Summary

- Silently ignore `resize()` calls after the PTY process has already exited instead of throwing `'Cannot resize a pty that has already exited'` (Windows)
- Catch `EBADF` errors on `resize()` when the PTY file descriptor is already closed and silently return instead of crashing (Unix)
- Prevents crashes on both platforms when a resize is triggered after process exit (e.g. during terminal cleanup)

Fixes #827

## Details

**Windows:** The native conpty `_exitCode` guard previously threw an error, which could crash the host process if the caller didn't wrap `resize()` in a try/catch. This is a race condition that's more likely to surface on Node.js v22 due to timing changes in its stream/event loop internals.

**Unix:** `pty.resize()` throws `'ioctl(2) failed, EBADF'` when the PTY file descriptor has already been closed before a resize event fires. The fix catches `EBADF` by both error code and message and silently returns.

## Test plan

- [ ] Reproduce crash from #827 on Windows + Node.js v22, confirm it no longer throws after this change
- [ ] Trigger a resize after PTY exit on Unix, confirm `EBADF` is no longer thrown
- [ ] Verify normal resize still works when PTY is active on both platforms