### PR TITLE
fix(unix): validate spawn-helper exists before calling pty.fork()

### DIFF
--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -366,6 +366,25 @@ if (process.platform !== 'win32') {
             done();
           });
         });
+        it('should throw a descriptive error when spawn-helper is missing', () => {
+          const { loadNativeModule } = require('./utils');
+          const nativeModule = loadNativeModule('pty');
+          const spawnHelperPath = path.resolve(__dirname, nativeModule.dir + '/spawn-helper');
+          const backupPath = spawnHelperPath + '.bak';
+          fs.renameSync(spawnHelperPath, backupPath);
+          try {
+            assert.throws(
+              () => new UnixTerminal('/bin/zsh', []),
+              (e: Error) => {
+                assert.ok(e.message.includes('spawn-helper not found'), `Unexpected message: ${e.message}`);
+                assert.ok(e.message.includes(spawnHelperPath), `Path missing from message: ${e.message}`);
+                return true;
+              }
+            );
+          } finally {
+            fs.renameSync(backupPath, spawnHelperPath);
+          }
+        });
         it('should not leak /dev/ptmx file descriptors after pty exit', async function(): Promise<void> {
           this.timeout(30000);
 

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -103,6 +103,9 @@ export class UnixTerminal extends Terminal {
     };
 
     // fork
+    if (!fs.existsSync(helperPath)) {
+      throw new Error(`node-pty spawn-helper not found at '${helperPath}'. This can happen if the application binary has moved since the process started.`);
+    }
     const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
 
     this._socket = new tty.ReadStream(term.fd);


### PR DESCRIPTION
## Problem

\`helperPath\` is computed **once at module load time** using \`__dirname\`:

\`\`\`ts
let helperPath = native.dir + '/spawn-helper';
helperPath = path.resolve(__dirname, helperPath);
\`\`\`

If the application binary moves after the process starts — for example, a dev build whose repository directory is relocated while the app is running — \`helperPath\` becomes stale. On the next call to \`pty.fork()\`, \`posix_spawn\` receives a non-existent path for \`argv[0]\` and returns \`ENOENT\`.

Previously this had two bad outcomes:

1. **Opaque error**: the native layer surfaced \`"posix_spawnp failed."\` with no path information, making diagnosis difficult.
2. **Process crash**: in some Electron/V8 versions, the \`Napi::Error\` thrown from the failed spawn path left V8 heap objects in an inconsistent state. A GC pass ~4 seconds later hit a \`CHECK\` failure and aborted the process with \`EXC_BREAKPOINT (SIGTRAP)\` — turning a recoverable error into a full application crash.

## Fix

Add an \`fs.existsSync\` guard in the \`UnixTerminal\` constructor before calling \`pty.fork()\`. This:

- Throws a clean JavaScript error before entering native code, keeping the process alive
- Includes the resolved \`helperPath\` in the error message for immediate diagnosis
- Is essentially free (one \`stat\` syscall) and only fails in the narrow case where the binary has moved

## Related

- The fd leak in \`pty_posix_spawn\` that contributed to the V8 heap corruption is already fixed in \`main\` via #882.
- This PR addresses the remaining gap: the JS layer never validates that the helper binary is reachable before delegating to native code.

## Testing

**Unit test** added in \`src/unixTerminal.test.ts\` under the existing \`darwin\`-only block in \`describe('spawn')\`. It temporarily renames the \`spawn-helper\` binary, asserts the constructor throws with a message containing both \`"spawn-helper not found"\` and the resolved path, then restores the binary in a \`finally\` block — the same rename-and-restore pattern used by the ptmx fd leak test added in #882. No additional dependencies required.

**Manual testing** via the Electron example (\`examples/electron\`) confirmed:
- Happy path: normal \`pty.spawn\` works correctly
- Error path: with \`spawn-helper\` renamed, the constructor throws a clean JS error and the process stays alive