### PR TITLE
Expose foreground process group PID on Unix

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,6 +19,11 @@ export interface ITerminal {
   pid: number;
 
   /**
+   * Gets the foreground process group ID, if available.
+   */
+  readonly foregroundPid?: number;
+
+  /**
    * Writes data to the socket.
    * @param data The data to write.
    */

--- a/src/native.d.ts
+++ b/src/native.d.ts
@@ -14,6 +14,7 @@ interface IUnixNative {
   fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
   open(cols: number, rows: number): IUnixOpenProcess;
   process(fd: number, pty?: string): string;
+  foregroundPid(fd: number): number | undefined;
   resize(fd: number, cols: number, rows: number, pixelWidth: number, pixelHeight: number): void;
 }
 

--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -256,6 +256,7 @@ Napi::Value PtyFork(const Napi::CallbackInfo& info);
 Napi::Value PtyOpen(const Napi::CallbackInfo& info);
 Napi::Value PtyResize(const Napi::CallbackInfo& info);
 Napi::Value PtyGetProc(const Napi::CallbackInfo& info);
+Napi::Value PtyGetForegroundPid(const Napi::CallbackInfo& info);
 
 /**
  * Functions
@@ -620,6 +621,30 @@ Napi::Value PtyGetProc(const Napi::CallbackInfo& info) {
 }
 
 /**
+ * Foreground Process Group PID
+ *
+ * Returns the pid of the foreground process group attached to the pty
+ * referenced by `fd`, or undefined if the lookup fails. Cross-platform
+ * (Linux + macOS) — wraps tcgetpgrp(3), which is what `process` already
+ * calls internally to resolve the foreground process name.
+ */
+Napi::Value PtyGetForegroundPid(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 1 || !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.foregroundPid(fd)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+  pid_t pgrp = tcgetpgrp(fd);
+  if (pgrp == -1) {
+    return env.Undefined();
+  }
+  return Napi::Number::New(env, static_cast<double>(pgrp));
+}
+
+/**
  * Nonblocking FD
  */
 
@@ -869,6 +894,7 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
   exports.Set("open",    Napi::Function::New(env, PtyOpen));
   exports.Set("resize",  Napi::Function::New(env, PtyResize));
   exports.Set("process", Napi::Function::New(env, PtyGetProc));
+  exports.Set("foregroundPid", Napi::Function::New(env, PtyGetForegroundPid));
   return exports;
 }
 

--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -288,6 +288,18 @@ if (process.platform !== 'win32') {
           }, 1000);
         });
       }
+      it('should return the foreground process group pid', (done) => {
+        const term = new UnixTerminal('node', ['-e', 'console.log("ready"); setTimeout(() => null, 200);']);
+        term.onData((data) => {
+          if (!data.includes('ready')) {
+            return;
+          }
+          assert.strictEqual(typeof term.foregroundPid, 'number');
+          assert.strictEqual(term.foregroundPid, term.pid);
+          term.on('exit', () => done());
+          term.kill();
+        });
+      });
       if (process.platform === 'darwin') {
         it('should return the name of the process', (done) => {
           const term = new UnixTerminal('/bin/echo');

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -173,6 +173,11 @@ export class UnixTerminal extends Terminal {
   /* Accessors */
   get fd(): number { return this._fd; }
   get ptsName(): string { return this._pty; }
+  /**
+   * Pid of the foreground process group attached to the pty, or undefined
+   * if the lookup fails (e.g. the pty has exited). Wraps tcgetpgrp(3).
+   */
+  get foregroundPid(): number | undefined { return pty.foregroundPid(this._fd); }
 
   /**
    * openpty

--- a/typings/node-pty.d.ts
+++ b/typings/node-pty.d.ts
@@ -121,6 +121,11 @@ declare module 'node-pty' {
     readonly pid: number;
 
     /**
+     * The foreground process group ID, if available.
+     */
+    readonly foregroundPid?: number;
+
+    /**
      * The column size in characters.
      */
     readonly cols: number;


### PR DESCRIPTION
**Unix terminals can now report the foreground process group PID directly through a new `foregroundPid` accessor.** `process` already calls `tcgetpgrp(3)` internally to resolve the foreground process *name*; this surfaces the underlying pgid so callers can identify the active foreground program without reverse-mapping from a process title.

The accessor returns `number | undefined` on Unix — `undefined` when the pty has exited or `tcgetpgrp` fails — and is optional on the public `IPty` type, since Windows/ConPTY has no equivalent concept. The native binding reuses the same syscall path the existing `PtyGetProc` already relies on, so there's no new platform surface.

*Motivating use case:* identifying which process owns a terminal's foreground when the process name alone is ambiguous — e.g. an interpreter-shimmed CLI whose kernel process name resolves to `node`.

### Verification

- `npm run build` (tsc) clean
- `npm test -- --grep "foreground process group"` passes on macOS arm64
- Rebased on latest `main`, no conflicts — a single additive commit

> Adds one accessor (`UnixTerminal.foregroundPid`), one native function (`PtyGetForegroundPid`), and one test. No change to existing APIs.

_Generated by Claude Code (model `claude-opus-4-8`)._