### PR TITLE
fix(unix): don't rewrite app.asar.unpacked paths a second time

### DIFF
--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -16,8 +16,18 @@ const native = loadNativeModule('pty');
 const pty: IUnixNative = native.module;
 let helperPath = native.dir + '/spawn-helper';
 helperPath = path.resolve(__dirname, helperPath);
-helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
-helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+// String.prototype.replace matches the first occurrence, so when helperPath
+// already contains 'app.asar.unpacked' (e.g. a caller of node-pty that
+// itself lives in app.asar.unpacked) the substring 'app.asar' matches the
+// prefix of 'app.asar.unpacked' and we'd produce 'app.asar.unpacked.unpacked'
+// — a path that doesn't exist on disk. Skip each rewrite if the unpacked
+// variant is already present.
+if (helperPath.indexOf('app.asar.unpacked') === -1) {
+  helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+}
+if (helperPath.indexOf('node_modules.asar.unpacked') === -1) {
+  helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+}
 
 const DEFAULT_FILE = 'sh';
 const DEFAULT_NAME = 'xterm';


### PR DESCRIPTION
## Summary

Fixes #923.

[`src/unixTerminal.ts#L19-L20`](https://github.com/microsoft/node-pty/blob/main/src/unixTerminal.ts#L19-L20) does:

```ts
helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
```

`String.prototype.replace` with a string argument matches the **first** occurrence. When the resolved \`helperPath\` already contains \`app.asar.unpacked/…\` (e.g. a caller of node-pty that itself lives inside \`app.asar.unpacked\`, bypassing Electron's asar shim — see #923 for the concrete repro), the substring \`app.asar\` matches the prefix of \`app.asar.unpacked\` and we produce a bogus \`…/app.asar.unpacked.unpacked/…\` path. \`posix_spawn\` then fails with \`ENOENT\` and node-pty surfaces the misleading \`posix_spawnp failed.\`.

This PR guards each rewrite so it only fires when the unpacked variant isn't already present.

## Test plan

- [x] Existing unix-terminal tests still pass (\`npm test\` → 17/17).
- [x] Manual repro on macOS arm64 from the linked issue's setup: before this patch \`pty.spawn\` throws \`posix_spawnp failed.\`; after this patch it spawns normally.