### PR TITLE
Add Cate to Real-world Uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ ptyProcess.write('ls\r');
 - [OpenSumi](https://github.com/opensumi/core): A framework helps you quickly build Cloud or Desktop IDE products.
 - [Enjoy Git](https://github.com/huangcs427/enjoy-git-release): A modern Git client featuring an intuitive user interface, built with Electron, Vue 3, and TypeScript.
 - [Logos](https://github.com/zixiao-labs/logos): A Modern, Lightweight Code Editor, built with Electron, Vue 3, and TypeScript.
+- [Cate](https://github.com/0-AI-UG/cate): An open source IDE on an infinite zoomable canvas, with editor, terminal, and browser panels in a spatial workspace. Built with Electron, React, and TypeScript.
 
 Do you use node-pty in your application as well? Please open a [Pull Request](https://github.com/Tyriar/node-pty/pulls) to include it here. We would love to have it in our list.
 


### PR DESCRIPTION
Adds Cate to the Real-world Uses list, as invited in the README. Cate is an open source desktop IDE on an infinite canvas. Its terminal panels are xterm.js frontends backed by node-pty.
