### PR TITLE
fix: close kqueue fd in SetupExitCallback on macOS

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -203,6 +203,7 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
         }
       }
     }
+    close(kq);
 #else
     while (true) {
       errno = 0;

--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -397,6 +397,37 @@ if (process.platform !== 'win32') {
             `Leaked ${finalCount - initialCount} /dev/ptmx FDs after spawning 20 PTYs (initial: ${initialCount}, final: ${finalCount})`
           );
         });
+        it('should not leak kqueue file descriptors after pty exit', async function(): Promise<void> {
+          this.timeout(30000);
+
+          const getKqueueFDCount = (): number => {
+            try {
+              const output = cp.execSync(`lsof -p ${process.pid} 2>/dev/null`, { encoding: 'utf8' });
+              return output.split('\n').filter(line => line.includes('KQUEUE')).length;
+            } catch {
+              return 0;
+            }
+          };
+
+          const initialCount = getKqueueFDCount();
+          for (let i = 0; i < 20; i++) {
+            const term = new UnixTerminal('/bin/bash', ['-c', 'echo hello']);
+            await new Promise<void>(resolve => {
+              term.onExit(() => {
+                term.destroy();
+                resolve();
+              });
+            });
+          }
+
+          await new Promise(r => setTimeout(r, 500));
+
+          const finalCount = getKqueueFDCount();
+          assert.ok(
+            finalCount <= initialCount,
+            `Leaked ${finalCount - initialCount} kqueue FDs after spawning 20 PTYs (initial: ${initialCount}, final: ${finalCount})`
+          );
+        });
       }
       it('should handle exec() errors', (done) => {
         const term = new UnixTerminal('/bin/bogus.exe', []);


### PR DESCRIPTION
Closes https://github.com/microsoft/node-pty/issues/907

On macOS, `SetupExitCallback` opens a `kqueue()` per spawned pty to wait on `NOTE_EXIT`, but never closes it before the watcher thread returns. This leaks one kqueue file descriptor per `pty.spawn()` for the lifetime of the host process.

Repro:
```js
const pty = require('node-pty');
const { execSync } = require('child_process');
const kq = () => execSync(`lsof -p ${process.pid} | grep -c KQUEUE`, {encoding:'utf8'}).trim();
(async () => {
  console.log('baseline KQUEUE=' + kq());
  for (let i = 0; i < 20; i++) {
    const p = pty.spawn('/bin/sh', [], { name: 'xterm', cols: 80, rows: 24 });
    await new Promise(r => { p.onExit(r); setTimeout(() => p.kill(), 50); });
  }
  await new Promise(r => setTimeout(r, 500));
  console.log('after 20 cycles KQUEUE=' + kq());  // baseline + 20
})();
```

The Chromium reference this code is based on ([kill_mac.cc](https://source.chromium.org/chromium/chromium/src/+/main:base/process/kill_mac.cc)) closes the kqueue via `ScopedFD`; the equivalent here is an explicit `close(kq)` once the kevent wait completes. `close(-1)` is a harmless EBADF if `kqueue()` itself failed, so no guard is needed.

Adds a regression test alongside the ptmx leak test from #882.

cc @deepak1556