### PR TITLE
fix: surface CreateProcessW failures as 'exit' instead of uncaughtException on Windows

### DIFF
--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -10,6 +10,7 @@ import { fork } from 'child_process';
 import { Socket } from 'net';
 import { ArgvOrCommandLine } from './types';
 import { ConoutConnection } from './windowsConoutConnection';
+import { EventEmitter2, IEvent } from './eventEmitter2';
 import { loadNativeModule } from './utils';
 
 let conptyNative: IConptyNative;
@@ -31,6 +32,9 @@ export class WindowsPtyAgent {
   private _closeTimeout: NodeJS.Timer | undefined;
   private _exitCode: number | undefined;
   private _conoutSocketWorker: ConoutConnection;
+
+  private _onError = new EventEmitter2<Error>();
+  public get onError(): IEvent<Error> { return this._onError.event; }
 
   private _fd: any;
   private _pty: number;
@@ -124,8 +128,21 @@ export class WindowsPtyAgent {
     const { pty, commandLine, cwd, env } = this._pendingPtyInfo;
     this._pendingPtyInfo = undefined;
 
-    const connect = conptyNative.connect(pty, commandLine, cwd, env, this._useConptyDll, c => this._$onProcessExit(c));
-    this._innerPid = connect.pid;
+    try {
+      const connect = conptyNative.connect(pty, commandLine, cwd, env, this._useConptyDll, c => this._$onProcessExit(c));
+      this._innerPid = connect.pid;
+    } catch (err) {
+      // connect() runs from the conout worker's onReady callback (or its
+      // timeout fallback), so a throw here would otherwise surface as an
+      // uncaughtException with no way for the consumer to observe it.
+      const code = /error code: (\d+)/.exec((err as Error).message)?.[1];
+      this._exitCode = code ? parseInt(code, 10) : -1;
+      try { this._ptyNative.kill(this._pty, this._useConptyDll); } catch { /* already gone */ }
+      this._conoutSocketWorker.dispose();
+      this._inSocket.destroy();
+      this._outSocket.destroy();
+      this._onError.fire(err as Error);
+    }
   }
 
   public resize(cols: number, rows: number): void {

--- a/src/windowsTerminal.test.ts
+++ b/src/windowsTerminal.test.ts
@@ -238,6 +238,20 @@ if (process.platform === 'win32') {
         });
       });
 
+      describe('connect failure', () => {
+        it('should emit exit instead of an uncaught exception when CreateProcessW fails', function (done) {
+          this.timeout(10000);
+          // Must exist (startProcess validates that) but not be a valid executable.
+          const notAnExe = path.join(__dirname, '..', 'package.json');
+          const term = new WindowsTerminal(notAnExe, [], { useConptyDll });
+          term.on('exit', (code) => {
+            assert.notStrictEqual(code, 0);
+            assert.strictEqual(term.pid, 0);
+            done();
+          });
+        });
+      });
+
       describe('On close', () => {
         it('should return process zero exit codes', function (done) {
           this.timeout(10000);

--- a/src/windowsTerminal.ts
+++ b/src/windowsTerminal.ts
@@ -50,6 +50,12 @@ export class WindowsTerminal extends Terminal {
     // Create new termal.
     this._agent = new WindowsPtyAgent(file, args, parsedEnv, cwd, this._cols, this._rows, false, opt.useConptyDll, opt.conptyInheritCursor);
     this._socket = this._agent.outSocket;
+    // The socket 'close' handler that drives 'exit' is only attached after
+    // ready_datapipe, which never fires when connect() fails.
+    this._agent.onError(() => {
+      this._close();
+      this.emit('exit', this._agent.exitCode);
+    });
 
     // Not available until `ready` event emitted.
     this._pid = this._agent.innerPid;


### PR DESCRIPTION
Since `connect()` was deferred to `_completePtyConnection()` (https://github.com/microsoft/node-pty/pull/885), a failure from `CreateProcessW` — `ERROR_FILE_NOT_FOUND`, `ERROR_ACCESS_DISABLED_BY_POLICY` (1260) under AppLocker/WDAC, etc. — throws from inside the conout worker's `onReady` callback (or its 5s timeout fallback). Nothing is in a position to catch it: `pty.spawn()` has already returned, and the `outSocket` `'close'` listener that drives `'exit'` isn't attached until `ready_datapipe`, which never fires. The throw lands as a process-level `uncaughtException`, the pseudoconsole and worker thread leak, and the consumer's `IPty` sits with `pid === 0` and no `onExit`.

Before https://github.com/microsoft/node-pty/pull/885 the same throw was synchronous inside the `WindowsPtyAgent` constructor and propagated out of `pty.spawn()`, so callers could `try { spawn() } catch`.

This adds an `onError` event on `WindowsPtyAgent` that `WindowsTerminal` subscribes to in its constructor (i.e., before any async work). On a `connect()` throw the agent releases the pseudoconsole, disposes the conout worker, destroys both sockets, sets `exitCode` to the `GetLastError()` value parsed from the native error string (or `-1`), and fires the event; `WindowsTerminal` routes it to `'exit'` so the public `onExit` fires.

Test exercises the path by spawning an existing non-executable file (`package.json`) — it passes `startProcess`'s existence check, then `CreateProcessW` fails inside `connect()` with `ERROR_BAD_EXE_FORMAT`.

cc @deepak1556 

