### PR TITLE
fix(unix): do not rewrite already-unpacked asar helper paths

### DIFF
--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -18,7 +18,37 @@ const FIXTURES_PATH = path.normalize(path.join(__dirname, '..', 'fixtures', 'utf
 if (process.platform !== 'win32') {
   // Dynamic require to avoid loading pty.node on Windows
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { UnixTerminal } = require('./unixTerminal') as { UnixTerminal: typeof UnixTerminalType };
+  const { UnixTerminal, resolveSpawnHelperPath } = require('./unixTerminal') as { UnixTerminal: typeof UnixTerminalType; resolveSpawnHelperPath: (nativeDir: string, moduleDir: string) => string };
+
+  describe('resolveSpawnHelperPath', () => {
+    it('rewrites a packed asar path to its unpacked form', () => {
+      const helperPath = resolveSpawnHelperPath(
+        '/Example.app/Contents/Resources/app.asar/node_modules/node-pty/build/Release',
+        '/Example.app/Contents/Resources/app.asar/node_modules/node-pty/lib');
+      assert.strictEqual(helperPath, '/Example.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper');
+    });
+
+    it('does not double-rewrite an already-unpacked asar path', () => {
+      const helperPath = resolveSpawnHelperPath(
+        '/Example.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release',
+        '/Example.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/lib');
+      assert.strictEqual(helperPath, '/Example.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper');
+    });
+
+    it('rewrites a packed node_modules.asar path to its unpacked form', () => {
+      const helperPath = resolveSpawnHelperPath(
+        '/app/node_modules.asar/node-pty/build/Release',
+        '/app/node_modules.asar/node-pty/lib');
+      assert.strictEqual(helperPath, '/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper');
+    });
+
+    it('does not double-rewrite an already-unpacked node_modules.asar path', () => {
+      const helperPath = resolveSpawnHelperPath(
+        '/app/node_modules.asar.unpacked/node-pty/build/Release',
+        '/app/node_modules.asar.unpacked/node-pty/lib');
+      assert.strictEqual(helperPath, '/app/node_modules.asar.unpacked/node-pty/build/Release/spawn-helper');
+    });
+  });
 
   describe('UnixTerminal', () => {
     describe('Constructor', () => {

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -14,10 +14,32 @@ import { assign, loadNativeModule } from './utils';
 
 const native = loadNativeModule('pty');
 const pty: IUnixNative = native.module;
-let helperPath = native.dir + '/spawn-helper';
-helperPath = path.resolve(__dirname, helperPath);
-helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
-helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+
+/**
+ * Resolve the absolute path of the platform spawn helper binary.
+ *
+ * @param nativeDir - the directory that holds the compiled native module.
+ * @param moduleDir - the directory of this module (resolves relative dirs).
+ * @returns the absolute spawn-helper path.
+ */
+export function resolveSpawnHelperPath(nativeDir: string, moduleDir: string): string {
+  let helperPath = path.resolve(moduleDir, nativeDir + '/spawn-helper');
+  // String.prototype.replace matches the first occurrence, so when helperPath
+  // already contains 'app.asar.unpacked' (e.g. node-pty is installed under an
+  // unpacked asar directory) the substring 'app.asar' matches the prefix of
+  // 'app.asar.unpacked' and produces 'app.asar.unpacked.unpacked' — a path
+  // that does not exist on disk. Skip each rewrite when the unpacked variant
+  // is already present.
+  if (helperPath.indexOf('app.asar.unpacked') === -1) {
+    helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+  }
+  if (helperPath.indexOf('node_modules.asar.unpacked') === -1) {
+    helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+  }
+  return helperPath;
+}
+
+const helperPath = resolveSpawnHelperPath(native.dir, __dirname);
 
 const DEFAULT_FILE = 'sh';
 const DEFAULT_NAME = 'xterm';


### PR DESCRIPTION
## Summary

Fixes #923. When node-pty is installed under `app.asar.unpacked` (the layout Electron apps use for native modules), the `helperPath` rewrite in `src/unixTerminal.ts` double-applies:

```ts
helperPath.replace('app.asar', 'app.asar.unpacked');
```

`String.prototype.replace` matches the first occurrence, which is the `app.asar` *prefix inside* `app.asar.unpacked`, producing `app.asar.unpacked.unpacked/.../spawn-helper`. That path does not exist, so on macOS every PTY spawn fails with `posix_spawnp failed.` (macOS is the only platform that spawns through the `spawn-helper` binary).

This PR extracts the resolution into `resolveSpawnHelperPath()` and skips each rewrite when the unpacked variant is already present. It is the same fix as #924 but with the logic factored into a pure, exported function so it can be regression-tested.

## Changes

- `src/unixTerminal.ts`: extract `resolveSpawnHelperPath(nativeDir, moduleDir)`; skip the `app.asar` / `node_modules.asar` rewrite when the `.unpacked` variant is already present.
- `src/unixTerminal.test.ts`: 4 regression tests covering packed → unpacked rewrite and already-unpacked (no double rewrite) for both `app.asar` and `node_modules.asar`.

## Verification

- **Pre-fix (regression tests fail):** with the unguarded rewrite, 2 of 4 new tests fail with the exact bug path:
  `'/app/node_modules.asar.unpacked.unpacked/node-pty/build/Release/spawn-helper'` (expected `.../app.asar.unpacked/...`).
- **Post-fix:** 4/4 pass; full suite 28 passing on macOS; `eslint src/` clean.
- **End-to-end (real runtime):** reproduced the failure inside the actual Electron runtime of a packaged app whose node-pty lives under `app.asar.unpacked` (`posix_spawnp failed.` for every spawn), then applied this change to that node-pty and confirmed a real PTY spawn of `/bin/bash` succeeds. Captured helper path before fix: `.../app.asar.unpacked.unpacked/node_modules/node-pty/build/Release/spawn-helper`; after: the correct single-unpacked path.

## Notes

- Overlaps with #924 (same behavioral fix); the added value here is the pure-function extraction and regression tests, which #924 lacks. Happy to rebase or close in favor of #924 if it merges first.
- Related: #917 (spawn-helper existence validation), #850 (executable-bit packaging issue), #91 in the downstream desktop app (`posix_spawnp failed` on macOS 26 in its minimal-mode persistent bash).

AI disclosure: this PR was developed with AI assistance (code + tests written with DeepSeek, reviewed and verified by a human) and is signed off by the human contributor.
