### PR TITLE
fix(unix): pace the EAGAIN write retry so a stalled reader can't saturate the thread

### DIFF
--- a/src/unixTerminal.test.ts
+++ b/src/unixTerminal.test.ts
@@ -124,6 +124,67 @@ if (process.platform !== 'win32') {
         term.destroy();
       });
     });
+    describe('EAGAIN backpressure', () => {
+      let realWrite: typeof fs.write;
+
+      beforeEach(() => {
+        realWrite = fs.write;
+      });
+
+      afterEach(() => {
+        (fs as any).write = realWrite;
+      });
+
+      it('should pace retries when the fd keeps returning EAGAIN', (done) => {
+        const term = new UnixTerminal('node', [ '-e', 'setInterval(() => {}, 1000)' ]);
+        let attempts = 0;
+        (fs as any).write = (fd: number, buf: Buffer, offset: number, cb: Function): void => {
+          attempts++;
+          const err: any = new Error('EAGAIN');
+          err.code = 'EAGAIN';
+          process.nextTick(() => cb(err));
+        };
+
+        term.write('trigger');
+        setTimeout(() => {
+          (fs as any).write = realWrite;
+          term.destroy();
+          // At 5ms pacing this is ~20 attempts in 100ms. An immediate re-attempt
+          // produces tens of thousands, which is the busy-loop being fixed.
+          assert.ok(attempts > 0, 'expected the EAGAIN path to be exercised');
+          assert.ok(attempts < 100, `expected paced retries, got ${attempts} attempts in 100ms`);
+          done();
+        }, 100);
+      });
+
+      it('should not write after dispose while a write is in flight', (done) => {
+        const term = new UnixTerminal('node', [ '-e', 'setInterval(() => {}, 1000)' ]);
+        let attempts = 0;
+        let release: (() => void) | undefined;
+        (fs as any).write = (fd: number, buf: Buffer, offset: number, cb: Function): void => {
+          attempts++;
+          const err: any = new Error('EAGAIN');
+          err.code = 'EAGAIN';
+          // Hold the completion so it lands *after* dispose, as a real in-flight
+          // write on the libuv threadpool would.
+          release = () => cb(err);
+        };
+
+        term.write('trigger');
+        setTimeout(() => {
+          const before = attempts;
+          term.destroy();
+          release!();
+          setTimeout(() => {
+            (fs as any).write = realWrite;
+            assert.strictEqual(attempts, before,
+              'a write was issued after dispose; the in-flight completion re-armed the retry');
+            done();
+          }, 50);
+        }, 20);
+      });
+    });
+
     describe('signals in parent and child', () => {
       it('SIGINT - custom in parent and child', done => {
         // this test is cumbersome - we have to run it in a sub process to

--- a/src/unixTerminal.ts
+++ b/src/unixTerminal.ts
@@ -309,6 +309,13 @@ interface IWriteTask {
 }
 
 /**
+ * How long to wait before re-attempting a write that returned EAGAIN. Large enough to
+ * stop the retry from monopolising the thread while a reader is stalled, small enough
+ * to be invisible to interactive writes.
+ */
+const EAGAIN_RETRY_DELAY_MS = 5;
+
+/**
  * A custom write stream that writes directly to a file descriptor with proper
  * handling of backpressure and errors. This avoids some event loop exhaustion
  * issues that can occur when using the standard APIs in Node.
@@ -316,7 +323,8 @@ interface IWriteTask {
 class CustomWriteStream implements IDisposable {
 
   private readonly _writeQueue: IWriteTask[] = [];
-  private _writeImmediate: NodeJS.Immediate | undefined;
+  private _writeRetry: NodeJS.Timeout | undefined;
+  private _isDisposed: boolean = false;
 
   constructor(
     private readonly _fd: number,
@@ -325,8 +333,9 @@ class CustomWriteStream implements IDisposable {
   }
 
   dispose(): void {
-    clearImmediate(this._writeImmediate);
-    this._writeImmediate = undefined;
+    this._isDisposed = true;
+    clearTimeout(this._writeRetry);
+    this._writeRetry = undefined;
   }
 
   write(data: string | Buffer): void {
@@ -345,7 +354,11 @@ class CustomWriteStream implements IDisposable {
   }
 
   private _processWriteQueue(): void {
-    this._writeImmediate = undefined;
+    if (this._isDisposed) {
+      return;
+    }
+
+    this._writeRetry = undefined;
 
     if (this._writeQueue.length === 0) {
       return;
@@ -357,11 +370,20 @@ class CustomWriteStream implements IDisposable {
     // than using the `net.Socket`/`tty.WriteStream` wrappers which swallow and
     // mask errors like EAGAIN and can cause the thread to block indefinitely.
     fs.write(this._fd, task.buffer, task.offset, (err, written) => {
+      // The fd may have been closed while this write was in flight. Anything below
+      // would either re-arm the retry or write again against a dead descriptor.
+      if (this._isDisposed) {
+        return;
+      }
+
       if (err) {
         if ('code' in err && err.code === 'EAGAIN') {
-          // `setImmediate` is used to yield to the event loop and re-attempt
-          // the write later.
-          this._writeImmediate = setImmediate(() => this._processWriteQueue());
+          // Re-attempt the write later. A delay rather than `setImmediate`: EAGAIN here
+          // means the reader has stopped draining the pty, so the branch keeps failing
+          // and an immediate re-attempt turns it into a busy-loop that saturates the
+          // thread. A reader that is merely slow applies backpressure without reaching
+          // this branch at all, so the delay does not throttle normal writes.
+          this._writeRetry = setTimeout(() => this._processWriteQueue(), EAGAIN_RETRY_DELAY_MS);
         } else {
           // Stop processing immediately on unexpected error and log
           this._writeQueue.length = 0;


### PR DESCRIPTION
## The problem

`CustomWriteStream._processWriteQueue()` retries an `EAGAIN` write with `setImmediate`, which re-attempts within microseconds:

https://github.com/microsoft/node-pty/blob/main/src/unixTerminal.ts#L362

When a pty's reader stops draining — a raw-mode child that has stopped reading — that branch never clears, so the retry becomes an unbounded busy-loop that saturates the thread it runs on.

For an embedder that multiplexes many PTYs onto one process this is not a local problem: **every terminal in the process freezes** — no output, no input — while the host machine looks perfectly healthy. That is how we found it. A terminal daemon pinned a core at 100% twice in one hour with ~143,000 EAGAIN/s in the syscall trace, and every session on it locked up for ~17 minutes.

## Why this doesn't undo #833

#833 removed `setTimeout`s from the backpressure path for throughput, and I did not want to quietly put one back. So I measured whether the EAGAIN branch is on that path at all.

Writing to a pty whose child **actively drains**, on macOS arm64:

| total written | baseline | with this change | EAGAINs seen |
|---|---|---|---|
| 4 MB | 240 ms | 240 ms | **0** |
| 32 MB | 2235 ms | 2450 ms | **0** |
| 64 MB | 4740 ms | 4927 ms | **0** |

**`EAGAIN` never fired once while a reader was draining, at any volume I tried.** A merely-slow reader applies backpressure through the normal completion path; the kernel only returns `EAGAIN` once the buffer is full *and stays* full, which requires the reader to have stopped. Throughput differences above are run-to-run noise (the baseline itself varies by more than that between runs).

So this paces a branch that only executes when throughput is already zero because nobody is reading. The fast path — write completes, queue advances from the completion callback — is untouched.

Caveat stated plainly: those measurements are macOS arm64 only. I have not measured Linux, where buffer sizing and `EAGAIN` behaviour could differ.

## The change

```diff
-  private _writeImmediate: NodeJS.Immediate | undefined;
+  private _writeRetry: NodeJS.Timeout | undefined;

   if ('code' in err && err.code === 'EAGAIN') {
-    this._writeImmediate = setImmediate(() => this._processWriteQueue());
+    this._writeRetry = setTimeout(() => this._processWriteQueue(), EAGAIN_RETRY_DELAY_MS);
   }
```

Renamed the field since it no longer holds an `Immediate`. `dispose()` correspondingly uses `clearTimeout`.

**Second, related fix:** `dispose()` clearing the handle is not sufficient on its own. An `fs.write` already **in flight** when `dispose()` runs still invokes its completion callback afterwards, and on `EAGAIN` that callback schedules a *fresh* retry — writing to an fd that is now closed. This is pre-existing (`setImmediate` does it too), but a delayed retry widens the window, so it belongs in the same change. Disposal is now tracked explicitly and checked in `_processWriteQueue()` and at the top of the completion callback.

`EBADF` is the benign outcome of that race. The one that concerns me is descriptor *recycling* — in a process that opens and closes PTYs continuously, a recycled fd would accept the write silently.

Waiting for actual writability (`kqueue`/`epoll` on the master fd) remains the fully correct fix, and is what #833 gestures at with "this likely needs a C++ solution like `poll`". This is the small version that stops the pathology in the meantime.

## Tests

Two tests added to `src/unixTerminal.test.ts`, both verified to fail without the fix:

| test | without fix | with fix |
|---|---|---|
| paces retries under sustained EAGAIN | **3,244 attempts / 100 ms** | ~20 |
| no write issued after dispose | write escapes → fails | passes |

They stub `fs.write` to return `EAGAIN` deterministically rather than trying to starve a real pty, so they are fast and not timing-flaky.

End-to-end against a real stalled pty (128 MB queued, 6 baseline / 5 patched trials): avg **49,160 – 120,608 EAGAIN/s → 175 – 178**, peak CPU **85 – 101% → 3 – 18%**.

`npm run lint` is clean.

⚠️ **On the full suite:** `npm test` on this machine (macOS 26.3, node 24, arm64) is already red before my change — 17–18 passing, 8–9 failing, and flaky run to run. The failures are all in `signals in parent and child` and `spawn` (`process.kill` receiving a NaN pid, and the fd-leak tests). Across four runs with my change the failing set is identical and my two new tests never appear in it; the passing count rises by exactly 2. I have not tried to fix those pre-existing failures here.

## Related

- #939 — same component, different failure mode: the threadpool stops delivering completions, so the queue never advances at all. Not addressed here.
- #833 — the issue this write path came from.
- stablyai/orca#11178 — the production incident, with syscall capture and a standalone reproducer.
