### PR TITLE
fix(unix): build on FreeBSD and other non-Linux, non-Apple platforms

### DIFF
--- a/src/unix/pty.cc
+++ b/src/unix/pty.cc
@@ -112,7 +112,7 @@ struct ExitEvent {
   int exit_code = 0, signal_code = 0;
 };
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 
 static int
 SetCloseOnExec(int fd) {
@@ -130,8 +130,15 @@ SetCloseOnExec(int fd) {
  */
 static void
 pty_close_inherited_fds() {
+  // FreeBSD 13+ exposes close_range(2) as a plain libc function; Linux
+  // reaches the same syscall through syscall(SYS_close_range, ...).
+  #if defined(__FreeBSD__) && defined(CLOSE_RANGE_CLOEXEC)
+  if (close_range(3, ~0U, CLOSE_RANGE_CLOEXEC) == 0) {
+    return;
+  }
+  #endif
   // Try close_range() first (Linux 5.9+, glibc 2.34+)
-  #if defined(SYS_close_range) && defined(CLOSE_RANGE_CLOEXEC)
+  #if defined(__linux__) && defined(SYS_close_range) && defined(CLOSE_RANGE_CLOEXEC)
   if (syscall(SYS_close_range, 3, ~0U, CLOSE_RANGE_CLOEXEC) == 0) {
     return;
   }


### PR DESCRIPTION
## Problem

`pty_close_inherited_fds()` and its `SetCloseOnExec()` helper are defined inside `#if defined(__linux__)` (src/unix/pty.cc:114-146), but the call site at src/unix/pty.cc:477 is in the `#else` branch of `#if defined(__APPLE__)` (line 393/418). That `#else` covers *every* non-Apple platform, not just Linux, so the call is emitted where the definition is not:

```
src/unix/pty.cc:477:7: error: use of undeclared identifier 'pty_close_inherited_fds'
  477 |       pty_close_inherited_fds();
      |       ^
1 error generated.
gmake: *** [pty.target.mk:115: Release/obj.target/pty/src/unix/pty.o] Error 1
```

macOS and Linux are both unaffected — the other BSDs are what break. This is the only thing standing between node-pty and a working FreeBSD build; nothing else in the tree needed touching.

## Fix

Compile the same helper on FreeBSD. The Linux implementation is already portable apart from its `close_range()` fast path:

- FreeBSD has had `close_range(2)` with `CLOSE_RANGE_CLOEXEC` since 13.0, declared in `<unistd.h>` with the flag in `<sys/unistd.h>`, so it is called directly as a libc function rather than through `syscall(SYS_close_range, ...)` — that spelling is Linux-specific.
- The `fcntl()` loop stays as the fallback for both platforms, unchanged.

Semantics are deliberately identical to Linux: descriptors are marked `FD_CLOEXEC`, not closed. `closefrom(3)` would close them outright, which is different behaviour and not what the caller expects.

The guard is widened to `__FreeBSD__` specifically rather than to "not Apple", since that is what I could actually test — the same one-line change would cover the other BSDs, but I would rather not claim platforms I have not built on.

## Verification

FreeBSD 15.1-RC2, amd64, node 24.14.1, node-gyp 12.4.0:

- `npx node-gyp rebuild` completes clean (`SOLINK_MODULE(target) Release/obj.target/pty.node`, `gyp info ok`).
- Runtime check — spawning a shell through `forkpty(3)`, reading its output and its exit code:

```js
const pty = require("./lib/index.js");
const p = pty.spawn("/bin/sh", ["-c", "echo PTY_WORKS_$((6*7))"], {
  name: "xterm-color", cols: 80, rows: 24, cwd: "/tmp", env: process.env,
});
let out = "";
p.onData(d => out += d);
p.onExit(({ exitCode }) => console.log("OUT:", out.trim(), "EXIT:", exitCode));
```

```
OUT: PTY_WORKS_42
EXIT: 0
```

Not tested on any other BSD, and no Linux or macOS behaviour is changed by this diff (both paths are byte-identical to before for those platforms).

## Context

This came out of getting an Electron/Bun-based tool running on FreeBSD, where node-pty was one of three native dependencies that needed porting. It was by far the smallest of the three — a genuine build bug rather than a missing platform.