### PR TITLE
fix(windows): hide the console window forked by the console-list agent

### DIFF
--- a/src/windowsPtyAgent.ts
+++ b/src/windowsPtyAgent.ts
@@ -6,7 +6,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { fork } from 'child_process';
+import { fork, ForkOptions } from 'child_process';
 import { Socket } from 'net';
 import { ArgvOrCommandLine } from './types';
 import { ConoutConnection, IConoutConnection } from './windowsConoutConnection';
@@ -228,7 +228,11 @@ export class WindowsPtyAgent {
       return Promise.resolve([]);
     }
     return new Promise<number[]>(resolve => {
-      const agent = fork(path.join(__dirname, 'conpty_console_list_agent'), [ this._innerPid.toString() ]);
+      // The helper needs a console (AttachConsole) but no window: without
+      // windowsHide, killing a pty flashes a console window on screen.
+      // Cast: @types/node's ForkOptions omits windowsHide.
+      const forkOptions = { windowsHide: true } as ForkOptions;
+      const agent = fork(path.join(__dirname, 'conpty_console_list_agent'), [ this._innerPid.toString() ], forkOptions);
       agent.on('message', message => {
         clearTimeout(timeout);
         resolve(message.consoleProcessList);


### PR DESCRIPTION
## What

`WindowsPtyAgent.kill()` calls `_getConsoleProcessList()`, which forks `conpty_console_list_agent`:

```ts
const agent = fork(path.join(__dirname, 'conpty_console_list_agent'), [ this._innerPid.toString() ]);
```

`fork()` inherits stdio, so on Windows that child is given a console of its own. The result is a console window appearing on screen every time a pty is killed. In an embedding application it can also take focus away from the host's window, which is how it surfaced for us.

## Change

Pass `windowsHide: true` to that fork. The helper still gets a console — it needs one, because `getConsoleProcessList()` calls `FreeConsole()` and then `AttachConsole(shellPid)` — it just has no window.

`fork()` spreads its options through to `spawn()` (`options = { __proto__: null, ...options, shell: false }`), which honours `windowsHide`, so nothing else about how the helper is started changes.

## Why the local is typed

`windowsHide` is honoured at runtime but is missing from `@types/node`'s `ForkOptions` — still true on DefinitelyTyped master — so passing it inline does not compile against `strict`:

```
error TS2353: Object literal may only specify known properties, and 'windowsHide' does not exist in type 'ForkOptions'.
```

The options object is typed with a cast to keep the build green. Happy to send the DefinitelyTyped change instead and drop the cast if you'd prefer that first.

## Verification

- `npm run build` (tsc, `strict`) and `npm run lint` pass.
- Full mocha suite: **57 passing, 0 failing**, which includes `kill › should kill the process tree` on the path this touches (`useConptyDll = false`). It polls the real process tree and still sees it removed, so the console-list sweep is unaffected by hiding the console.
- The agent itself, queried directly against a live pty with and without the option, attaches either way and returns the shell pid in the list (45 ms vs 37 ms, no timeout).

## Not covered here

- **#937** asks for an opt-in `windowsHide` for spawned processes. This does not implement that. It only stops the window for the *internal* helper on kill, which no caller can currently suppress.
- **#952** is about this same fork losing its race with the pseudoconsole teardown, and about the child's stderr being inherited because `fork()` defaults to `silent: false`. This change doesn't address either; it only removes the window.
